### PR TITLE
Signature native_to_bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,16 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+execute_process(COMMAND git submodule status --recursive
+                COMMAND grep -c "^[+\-]"
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE submodule_status
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(submodule_status GREATER 0)
+   message(FATAL_ERROR "git submodules are not up to date.
+Please run the command 'git submodule update --init --recursive'.")
+endif()
+
 add_library(abieos MODULE src/abieos.cpp)
 target_include_directories(abieos PRIVATE external/rapidjson/include external/date/include)
 

--- a/src/abieos.hpp
+++ b/src/abieos.hpp
@@ -848,6 +848,8 @@ ABIEOS_NODISCARD inline bool bin_to_json(private_key*, bin_to_json_state& state,
     return state.writer.String(result.c_str(), result.size());
 }
 
+inline void native_to_bin(const signature& obj, std::vector<char>& bin) { push_raw(bin, obj); }
+
 ABIEOS_NODISCARD inline bool bin_to_native(signature& obj, bin_to_native_state& state, bool) {
     return read_raw(state.bin, state.error, obj);
 }


### PR DESCRIPTION
- adds a `native_to_bin` function for `signature` types
- check `git submodule status` upon cmake