### PR TITLE
add cmake INTERFACE for using abieos headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ endif()
 add_library(abieos MODULE src/abieos.cpp)
 target_include_directories(abieos PRIVATE external/rapidjson/include external/date/include)
 
+add_library(abieos_headers INTERFACE)
+target_include_directories(abieos_headers INTERFACE src external/date/include external/rapidjson/include)
+
 add_executable(test src/test.cpp src/abieos.cpp)
 target_include_directories(test PRIVATE external/rapidjson/include external/date/include)
 


### PR DESCRIPTION
downstream C++ users of abieos shouldn't have to manually know and specify the proper include directories. This adds a cmake INTERFACE target caled `abieos_headers` that can be used to bring in the include directories.

For example, now it's as simple to use as:
```cmake
add_library(lightvalidator lightvalidator.cpp)
target_link_libraries(lightvalidator abieos_headers)
```