### PR TITLE
Names now fall back to hash if invalid chars found

### DIFF
--- a/include/eosio/chain_conversions.hpp
+++ b/include/eosio/chain_conversions.hpp
@@ -68,12 +68,17 @@ inline uint64_t string_to_name(const std::string& str) { return string_to_name(s
    unsigned i = 0;
    for (; i < str.size() && i < 12; ++i) {
       uint64_t x = 0;
-      OUTCOME_TRY(char_to_name_digit_strict(str[i], x));
+      // - this is not safe in const expression OUTCOME_TRY(char_to_name_digit_strict(str[i], x));
+      auto r = char_to_name_digit_strict(str[i], x);
+      if( !r ) return stream_error::invalid_name_char;
       name |= (x & 0x1f) << (64 - 5 * (i + 1));
    }
    if (i < str.size() && i == 12) {
       uint64_t x = 0;
-      OUTCOME_TRY(char_to_name_digit_strict(str[i], x));
+      // - this is not safe in const expression OUTCOME_TRY(char_to_name_digit_strict(str[i], x));
+      auto r = char_to_name_digit_strict(str[i], x);
+      if( !r ) return stream_error::invalid_name_char;
+
       if (x != (x & 0xf))
          return stream_error::invalid_name_char13;
       name |= x;

--- a/include/eosio/from_bin.hpp
+++ b/include/eosio/from_bin.hpp
@@ -11,6 +11,7 @@
 #include <tuple>
 #include <variant>
 #include <vector>
+#include <string_view>
 
 namespace eosio {
 
@@ -213,6 +214,16 @@ inline result<void> from_bin(std::string& obj, S& stream) {
       return r;
    obj.resize(size);
    return stream.read(obj.data(), obj.size());
+}
+
+template <typename S>
+inline result<void> from_bin(std::string_view& obj, S& stream) {
+   uint32_t size;
+   auto     r = varuint32_from_bin(size, stream);
+   if (!r)
+      return r;
+   obj = std::string_view(stream.get_pos(),size);
+   return stream.skip(size);
 }
 
 template <typename T, typename S>

--- a/include/eosio/murmur.hpp
+++ b/include/eosio/murmur.hpp
@@ -1,0 +1,55 @@
+  
+namespace eosio {
+namespace {
+  inline constexpr uint64_t unaligned_load(const char* p)
+  {
+    uint64_t r = 0;
+    for( uint32_t i = 0; i < 8; ++i ) {
+       r |= p[i];
+       r <<= 8;
+    }
+    return r;
+  }
+
+  // Loads n bytes, where 1 <= n < 8.
+  inline constexpr uint64_t load_bytes(const char* p, int n)
+  {
+    std::uint64_t result = 0;
+    --n;
+    do
+      result = (result << 8) +  (unsigned char)(p[n]);
+    while (--n >= 0);
+    return result;
+  }
+
+  inline constexpr uint64_t shift_mix(std::uint64_t v)
+  { return v ^ (v >> 47);}
+}
+
+// Implementation of Murmur hash for 64-bit size_t.
+  inline constexpr uint64_t murmur64(const char* ptr, uint64_t len, uint64_t seed = 0xbadd00d00)
+  {
+    const uint64_t mul = (((uint64_t) 0xc6a4a793UL) << 32UL)
+			      + (uint64_t) 0x5bd1e995UL;
+    const char* const buf = ptr;
+
+    // Remove the bytes not divisible by the sizeof(uint64_t).  This
+    // allows the main loop to process the data as 64-bit integers.
+    const uint64_t len_aligned = len & ~(uint64_t)0x7;
+    const char* const end = buf + len_aligned;
+    uint64_t hash = seed ^ (len * mul);
+    for (const char* p = buf; p != end; p += 8) {
+     const uint64_t data = shift_mix(unaligned_load(p) * mul) * mul;
+     hash ^= data;
+     hash *= mul;
+    }
+    if ((len & 0x7) != 0) {
+     const uint64_t data = load_bytes(end, len & 0x7);
+     hash ^= data;
+     hash *= mul;
+    }
+    hash = shift_mix(hash) * mul;
+    hash = shift_mix(hash);
+    return hash;
+  }
+} // namespace eosio

--- a/include/eosio/stream.hpp
+++ b/include/eosio/stream.hpp
@@ -187,6 +187,8 @@ struct input_stream {
       return outcome::success();
    }
 
+   auto get_pos()const { return pos; }
+
    result<void> read(void* dest, size_t size) {
       if (size > size_t(end - pos))
          return stream_error::overrun;

--- a/include/eosio/to_json.hpp
+++ b/include/eosio/to_json.hpp
@@ -135,7 +135,7 @@ result<void> fp_to_json(double value, S& stream) {
    } else if (std::isnan(value)) {
       return stream.write("\"NaN\"", 5);
    }
-   small_buffer<std::numeric_limits<double>::digits10 + 2> b;
+   small_buffer<std::numeric_limits<double>::digits10 + 20> b;
    int                                                     n = fpconv_dtoa(value, b.pos);
    if (n <= 0)
       return stream_error::float_error;


### PR DESCRIPTION
- add a new ""_h to indicate that fallback is desired behavior
- json strings now convert via _h by default instead of assert
- updated string_to_name_strict to be safe for constexpr in failure case