### PR TITLE
replace abieos_headers target with a new abieos library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,27 +31,29 @@ Please run the command 'git submodule update --init --recursive'.")
   endif()
 endif()
 
-add_library(abieos MODULE src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
-target_include_directories(abieos PRIVATE include external/outcome/single-header external/rapidjson/include external/date/include)
+add_library(abieos STATIC src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
+target_include_directories(abieos PUBLIC include external/outcome/single-header external/rapidjson/include external/date/include)
+set_target_properties(abieos PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-add_library(abieos_headers INTERFACE)
-target_include_directories(abieos_headers INTERFACE include external/outcome/single-header external/date/include external/rapidjson/include)
+add_library(abieos_module MODULE src/abieos.cpp)
+target_link_libraries(abieos_module abieos)
+set_target_properties(abieos_module PROPERTIES OUTPUT_NAME "abieos")
 
-add_executable(test src/test.cpp src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
-target_include_directories(test PRIVATE include external/outcome/single-header external/rapidjson/include external/date/include)
+add_executable(test src/test.cpp src/abieos.cpp)
+target_link_libraries(test abieos)
 
-add_executable(template_test src/template_test.cpp src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
-target_include_directories(template_test PRIVATE include external/outcome/single-header external/rapidjson/include external/date/include)
+add_executable(template_test src/template_test.cpp src/abieos.cpp)
+target_link_libraries(template_test abieos)
 
-add_executable(key_test src/key_test.cpp src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
-target_include_directories(key_test PRIVATE include external/outcome/single-header external/rapidjson/include external/date/include)
+add_executable(key_test src/key_test.cpp src/abieos.cpp)
+target_link_libraries(key_test abieos)
 
 add_executable(reflect_test src/reflect_test.cpp)
 target_include_directories(reflect_test PRIVATE include)
 
-add_executable(test-sanitize src/test.cpp src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
+add_executable(test-sanitize src/test.cpp src/abieos.cpp)
 target_include_directories(test-sanitize PRIVATE include external/outcome/single-header external/rapidjson/include external/date/include)
-target_link_libraries(test-sanitize -fno-omit-frame-pointer -fsanitize=address,undefined)
+target_link_libraries(test-sanitize abieos -fno-omit-frame-pointer -fsanitize=address,undefined)
 target_compile_options(test-sanitize PUBLIC -fno-omit-frame-pointer -fsanitize=address,undefined)
 
 # add_executable(fuzzer src/fuzzer.cpp src/abieos.cpp)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # copyright defined in abieos/LICENSE.txt
 
 add_executable(name name.cpp)
-target_link_libraries(name abieos_headers)
+target_link_libraries(name abieos)
 
 add_custom_command( TARGET name POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:name> ${CMAKE_CURRENT_BINARY_DIR}/name2num )
 add_custom_command( TARGET name POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE:name> ${CMAKE_CURRENT_BINARY_DIR}/num2name )


### PR DESCRIPTION
abieos is no longer header only. Downstream C++ users simply including abieos via cmake will not get the entirely of the library via `abieos_headers`

This change removes the `abieos_headers` target and replaces it with a new `abieos` static library target that includes the .cpp files for abieos. I don't _think_ we want abieos.cpp in here, someone else correct me if so. Now downstream C++ users can simply `target_link_libraries(target abieos)` and all functionality is there.

The previous `abieos MODULE` target is renamed to `abieos_module` and is fixed up to still result in an output file of libabieos.so