### PR TITLE
Fix incorrect loop condition that caused utf-8 validation to swallow …

### DIFF
--- a/include/eosio/to_json.hpp
+++ b/include/eosio/to_json.hpp
@@ -38,16 +38,14 @@ result<void> to_json(std::string_view sv, S& stream) {
    while (begin != end) {
       auto pos = begin;
       while (pos != end && *pos != '"' && *pos != '\\' && (unsigned char)(*pos) >= 32 && *pos != 127) ++pos;
-      if (begin != pos) {
-         while (begin != end) {
-            stream_adaptor s2(begin, static_cast<std::size_t>(pos - begin));
-            if (rapidjson::UTF8<>::Validate(s2, s2)) {
-               OUTCOME_TRY(stream.write(begin, s2.idx));
-               begin += s2.idx;
-            } else {
-               ++begin;
-               OUTCOME_TRY(stream.write('?'));
-            }
+      while (begin != pos) {
+         stream_adaptor s2(begin, static_cast<std::size_t>(pos - begin));
+         if (rapidjson::UTF8<>::Validate(s2, s2)) {
+            OUTCOME_TRY(stream.write(begin, s2.idx));
+            begin += s2.idx;
+         } else {
+            ++begin;
+            OUTCOME_TRY(stream.write('?'));
          }
       }
       if (begin != end) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -569,6 +569,7 @@ void check_types() {
     check_type(context, 0, "string", R"("' + '*'.repeat(128) + '")");
     check_type(context, 0, "string", R"("\u0000  这是一个测试  Это тест  هذا اختبار 👍")");
     check(abieos_bin_to_json(context, 0, "string", "\x11invalid utf8: \xff\xfe\xfd", 18) == std::string(R"("invalid utf8: ???")"), "invalid utf8");
+    check(abieos_bin_to_json(context, 0, "string", "\4\xe8\xbf\x99\n", 5) == std::string("\"\xe8\xbf\x99\\u000A\""), "escaping");
     check_error(context, "Stream overrun", [&] { return abieos_hex_to_json(context, 0, "string", "01"); });
     check_type(context, 0, "checksum160", R"("0000000000000000000000000000000000000000")");
     check_type(context, 0, "checksum160", R"("123456789ABCDEF01234567890ABCDEF70123456")");


### PR DESCRIPTION
…the entire string.