### PR TITLE
expose a generic from_base58() too

### DIFF
--- a/include/eosio/crypto.hpp
+++ b/include/eosio/crypto.hpp
@@ -153,6 +153,7 @@ result<void> from_json(signature& obj, S& stream) {
    return outcome::success();
 }
 
- std::string to_base58(const char* d, size_t s );
+std::string to_base58(const char* d, size_t s );
+result<std::vector<char>> from_base58(const std::string_view& s);
 
 } // namespace eosio

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -200,4 +200,10 @@ namespace eosio {
     std::string to_base58(const char* d, size_t s ) { 
         return binary_to_base58( std::string_view(d,s) );
     }
+
+    result<std::vector<char>> from_base58(const std::string_view& s) {
+        std::vector<char> ret;
+        OUTCOME_TRY( base58_to_binary( ret, s) );
+        return ret;
+    }
 }


### PR DESCRIPTION
`to_base58()` was added to public interface. a `from_base58()` is useful too so how about it?