### PR TITLE
Add block_info

### DIFF
--- a/include/eosio/chain_types.hpp
+++ b/include/eosio/chain_types.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "ship_protocol.hpp"
+
+namespace chain_types {
+using namespace eosio::ship_protocol;
+
+struct block_info {
+   uint32_t               block_num = {};
+   eosio::checksum256     block_id  = {};
+   eosio::block_timestamp timestamp;
+};
+
+EOSIO_REFLECT(block_info, block_num, block_id, timestamp);
+}; // namespace chain_types

--- a/include/eosio/ship_protocol.hpp
+++ b/include/eosio/ship_protocol.hpp
@@ -847,12 +847,4 @@ namespace eosio { namespace ship_protocol {
 
    using resource_limits_config = std::variant<resource_limits_config_v0>;
 
-   struct block_info {
-      uint32_t               block_num = {};
-      eosio::checksum256     block_id  = {};
-      eosio::block_timestamp timestamp;
-   };
-
-   EOSIO_REFLECT(block_info, block_num, block_id, timestamp);
-
 }} // namespace eosio::ship_protocol

--- a/include/eosio/ship_protocol.hpp
+++ b/include/eosio/ship_protocol.hpp
@@ -182,6 +182,7 @@ namespace eosio { namespace ship_protocol {
    };
 
    EOSIO_REFLECT(account_auth_sequence, account, sequence)
+   EOSIO_COMPARE(account_auth_sequence);
 
    struct action_receipt_v0 {
       eosio::name                        receiver        = {};
@@ -204,6 +205,7 @@ namespace eosio { namespace ship_protocol {
    };
 
    EOSIO_REFLECT(account_delta, account, delta)
+   EOSIO_COMPARE(account_delta);
 
    struct action_trace_v0 {
       eosio::varuint32              action_ordinal         = {};
@@ -844,5 +846,13 @@ namespace eosio { namespace ship_protocol {
                  account_cpu_usage_average_window, account_net_usage_average_window)
 
    using resource_limits_config = std::variant<resource_limits_config_v0>;
+
+   struct block_info {
+      uint32_t               block_num = {};
+      eosio::checksum256     block_id  = {};
+      eosio::block_timestamp timestamp;
+   };
+
+   EOSIO_REFLECT(block_info, block_num, block_id, timestamp);
 
 }} // namespace eosio::ship_protocol


### PR DESCRIPTION
Added block_info,  comparators for account_auth_sequence and account_delta so the types in ship_protocol namespace can be used as chain_types in eosio-tester