### PR TITLE
Add support for action_results

### DIFF
--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -124,6 +124,13 @@ struct variant_def {
 
 EOSIO_REFLECT(variant_def, name, types);
 
+struct action_result_def {
+    eosio::name name{};
+    std::string result_type{};
+};
+
+EOSIO_REFLECT(action_result_def, name, result_type);
+
 struct abi_def {
     std::string version{};
     std::vector<type_def> types{};
@@ -134,10 +141,11 @@ struct abi_def {
     std::vector<error_message> error_messages{};
     abi_extensions_type abi_extensions{};
     might_not_exist<std::vector<variant_def>> variants{};
+    might_not_exist<std::vector<action_result_def>> action_results{};
 };
 
 EOSIO_REFLECT(abi_def, version, types, structs, actions, tables, ricardian_clauses, error_messages, abi_extensions,
-              variants);
+              variants, action_results);
 
 struct abi_type;
 
@@ -198,6 +206,7 @@ struct abi {
     std::map<eosio::name, std::string> action_types;
     std::map<eosio::name, std::string> table_types;
     std::map<std::string, abi_type> abi_types;
+    std::map<eosio::name, std::string> action_result_types;
     const abi_type* get_type(const std::string& name);
 
     // Adds a type to the abi.  Has no effect if the type is already present.

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -188,6 +188,8 @@ void eosio::convert(const abi_def& abi, eosio::abi& c) {
         c.action_types[a.name] = a.type;
     for (auto& t : abi.tables)
         c.table_types[t.name] = t.type;
+    for (auto& r : abi.action_results.value)
+        c.action_result_types[r.name] = r.result_type;
     for_each_abi_type([&](auto* p) {
         const char* name = get_type_name(p);
         c.abi_types.try_emplace(name, name, abi_type::builtin{}, &abi_serializer_for<std::decay_t<decltype(*p)>>);

--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -181,6 +181,21 @@ extern "C" const char* abieos_get_type_for_table(abieos_context* context, uint64
     });
 }
 
+extern "C" const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract, uint64_t action_result) {
+    return handle_exceptions(context, nullptr, [&] {
+        auto contract_it = context->contracts.find(::abieos::name{contract});
+        if (contract_it == context->contracts.end())
+            throw std::runtime_error("contract \"" + eosio::name_to_string(contract) + "\" is not loaded");
+        auto& c = contract_it->second;
+
+        auto action_result_it = c.action_result_types.find(name{action_result});
+        if (action_result_it == c.action_result_types.end())
+            throw std::runtime_error("contract \"" + eosio::name_to_string(contract) + "\" does not have action_result \"" +
+                                     eosio::name_to_string(action_result) + "\"");
+        return action_result_it->second.c_str();
+    });
+}
+
 extern "C" abieos_bool abieos_json_to_bin(abieos_context* context, uint64_t contract, const char* type,
                                           const char* json) {
     fix_null_str(type);

--- a/src/abieos.h
+++ b/src/abieos.h
@@ -52,6 +52,10 @@ const char* abieos_get_type_for_action(abieos_context* context, uint64_t contrac
 // to retrieve error.
 const char* abieos_get_type_for_table(abieos_context* context, uint64_t contract, uint64_t table);
 
+// Get the type name for an action_result. The contract owns the returned memory. Returns null on error; use abieos_get_error
+// to retrieve error.
+const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract, uint64_t action_result);
+
 // Convert json to binary. Use abieos_get_bin_* to retrieve result. Returns false on error.
 abieos_bool abieos_json_to_bin(abieos_context* context, uint64_t contract, const char* type, const char* json);
 

--- a/src/abieos.h
+++ b/src/abieos.h
@@ -44,15 +44,15 @@ abieos_bool abieos_set_abi_bin(abieos_context* context, uint64_t contract, const
 // Set abi (hex format). Returns false on error.
 abieos_bool abieos_set_abi_hex(abieos_context* context, uint64_t contract, const char* hex);
 
-// Get the type name for an action. The contract owns the returned memory. Returns null on error; use abieos_get_error
+// Get the type name for an action. The context owns the returned memory. Returns null on error; use abieos_get_error
 // to retrieve error.
 const char* abieos_get_type_for_action(abieos_context* context, uint64_t contract, uint64_t action);
 
-// Get the type name for a table. The contract owns the returned memory. Returns null on error; use abieos_get_error
+// Get the type name for a table. The context owns the returned memory. Returns null on error; use abieos_get_error
 // to retrieve error.
 const char* abieos_get_type_for_table(abieos_context* context, uint64_t contract, uint64_t table);
 
-// Get the type name for an action_result. The contract owns the returned memory. Returns null on error; use abieos_get_error
+// Get the type name for an action_result. The context owns the returned memory. Returns null on error; use abieos_get_error
 // to retrieve error.
 const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract, uint64_t action_result);
 


### PR DESCRIPTION
## Change Description

This updates abieos to support action return values. These are referred to as `action_results` in the generated abi.

## Change Type
**Select ONE**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the relase notes. Please include a description of the change for inclusion in the release notes.-->


## Consensus Changes
- [ ] Consensus Changes

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
