### PR TITLE
Add kv tables to the abi

### DIFF
--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -131,6 +131,27 @@ struct action_result_def {
 
 EOSIO_REFLECT(action_result_def, name, result_type);
 
+struct primary_key_index_def {
+   std::string name{};
+   std::string type;
+};
+
+EOSIO_REFLECT(primary_key_index_def, name, type);
+
+struct secondary_index_def {
+   std::string type;
+};
+
+EOSIO_REFLECT(secondary_index_def, type);
+
+struct kv_table_entry_def {
+   std::string type;
+   primary_key_index_def primary_index;
+   std::map<std::string, secondary_index_def> secondary_indices;
+};
+
+EOSIO_REFLECT(kv_table_entry_def, type, primary_index, secondary_indices);
+
 struct abi_def {
     std::string version{};
     std::vector<type_def> types{};
@@ -142,10 +163,11 @@ struct abi_def {
     abi_extensions_type abi_extensions{};
     might_not_exist<std::vector<variant_def>> variants{};
     might_not_exist<std::vector<action_result_def>> action_results{};
+    might_not_exist<std::map<eosio::name, kv_table_entry_def>> kv_tables{};
 };
 
 EOSIO_REFLECT(abi_def, version, types, structs, actions, tables, ricardian_clauses, error_messages, abi_extensions,
-              variants, action_results);
+              variants, action_results, kv_tables);
 
 struct abi_type;
 
@@ -205,6 +227,7 @@ struct abi_type {
 struct abi {
     std::map<eosio::name, std::string> action_types;
     std::map<eosio::name, std::string> table_types;
+    std::map<eosio::name, std::string> kv_tables;
     std::map<std::string, abi_type> abi_types;
     std::map<eosio::name, std::string> action_result_types;
     const abi_type* get_type(const std::string& name);

--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -132,7 +132,7 @@ struct action_result_def {
 EOSIO_REFLECT(action_result_def, name, result_type);
 
 struct primary_key_index_def {
-   std::string name{};
+   eosio::name name{};
    std::string type;
 };
 
@@ -147,7 +147,7 @@ EOSIO_REFLECT(secondary_index_def, type);
 struct kv_table_entry_def {
    std::string type;
    primary_key_index_def primary_index;
-   std::map<std::string, secondary_index_def> secondary_indices;
+   std::map<eosio::name, secondary_index_def> secondary_indices;
 };
 
 EOSIO_REFLECT(kv_table_entry_def, type, primary_index, secondary_indices);

--- a/include/eosio/from_json.hpp
+++ b/include/eosio/from_json.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <variant>
 #include <errno.h>
+#include <map>
 
 namespace eosio {
 enum class from_json_error {
@@ -560,6 +561,17 @@ void from_json(std::optional<T>& result, S& stream) {
       from_json(*result, stream);
    }
 }
+
+/// \output_section Parse JSON 
+/// Parse JSON and convert to `map`. This overload works with
+/// [reflected objects](standardese://reflection/).
+template <typename Key, typename Val, typename S>
+void from_json(std::map<Key, Val>& result, S& stream) {
+   from_json_object(stream, [&](std::string_view key) {
+      from_json(result[Key(key)], stream);
+   });
+}
+
 
 template <int N = 0, typename... T>
 void set_variant_impl(std::variant<T...>& result, uint32_t type) {

--- a/include/eosio/to_json.hpp
+++ b/include/eosio/to_json.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <rapidjson/encodings.h>
 #include <variant>
+#include <map>
 
 namespace eosio {
 
@@ -165,6 +166,29 @@ void to_json(const std::vector<T>& obj, S& stream) {
       write_newline(stream);
    }
    stream.write(']');
+}
+
+template <typename K, typename V, typename S>
+void to_json(const std::map<K, V>& obj, S& stream) {
+   stream.write('{');
+   bool first = true;
+   for (const auto& [k,v] : obj) {
+      if (first) {
+         increase_indent(stream);
+      } else {
+         stream.write(',');
+      }
+      write_newline(stream);
+      first = false;
+      to_json(k, stream);
+      stream.write(':');
+      to_json(v, stream);
+   }
+   if (!first) {
+      decrease_indent(stream);
+      write_newline(stream);
+   }
+   stream.write('}');
 }
 
 template <typename T, typename S>

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -225,6 +225,13 @@ void eosio::convert(const abi_def& abi, eosio::abi& c) {
     for (auto& [_, t] : c.abi_types) {
         fill(c.abi_types, t, 0);
     }
+
+    for (const auto& [key, val] : abi.kv_tables.value) {
+        std::vector<char> bytes;
+        eosio::vector_stream strm(bytes);
+        to_json(val, strm);
+        c.kv_tables.try_emplace(key, bytes.begin(), bytes.end());
+    }
 }
 
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::builtin&) {}

--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -181,6 +181,21 @@ extern "C" const char* abieos_get_type_for_table(abieos_context* context, uint64
     });
 }
 
+extern "C" const char* abieos_get_kv_table_def(abieos_context* context, uint64_t contract, uint64_t table) {
+    return handle_exceptions(context, nullptr, [&] {
+        auto contract_it = context->contracts.find(::abieos::name{contract});
+        if (contract_it == context->contracts.end())
+            throw std::runtime_error("contract \"" + eosio::name_to_string(contract) + "\" is not loaded");
+        auto& c = contract_it->second;
+
+        auto table_it = c.kv_tables.find(name{table});
+        if (table_it == c.kv_tables.end())
+            throw std::runtime_error("contract \"" + eosio::name_to_string(contract) + "\" does not have kv table \"" +
+                                        eosio::name_to_string(table) + "\"");
+        return table_it->second.c_str();
+    });
+}
+
 extern "C" const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract, uint64_t action_result) {
     return handle_exceptions(context, nullptr, [&] {
         auto contract_it = context->contracts.find(::abieos::name{contract});

--- a/src/abieos.h
+++ b/src/abieos.h
@@ -52,6 +52,10 @@ const char* abieos_get_type_for_action(abieos_context* context, uint64_t contrac
 // to retrieve error.
 const char* abieos_get_type_for_table(abieos_context* context, uint64_t contract, uint64_t table);
 
+// Get the definition for a kv table in json. The context owns the returned memory. Returns null on error; use abieos_get_error
+// to retrieve error.
+const char* abieos_get_kv_table_def(abieos_context* context, uint64_t contract, uint64_t table);
+
 // Get the type name for an action_result. The context owns the returned memory. Returns null on error; use abieos_get_error
 // to retrieve error.
 const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract, uint64_t action_result);

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -246,6 +246,143 @@ const char transactionAbi[] = R"({
     ]
 })";
 
+const char testKvTablesAbi[] = R"({
+    "version": "eosio::abi/1.2",
+    "types": [],
+    "structs": [
+        {
+            "name": "get",
+            "base": "",
+            "fields": []
+        },
+        {
+            "name": "iteration",
+            "base": "",
+            "fields": []
+        },
+        {
+            "name": "my_struct",
+            "base": "",
+            "fields": [
+                {
+                    "name": "primary",
+                    "type": "name"
+                },
+                {
+                    "name": "foo",
+                    "type": "string"
+                },
+                {
+                    "name": "bar",
+                    "type": "uint64"
+                },
+                {
+                    "name": "fullname",
+                    "type": "string"
+                },
+                {
+                    "name": "age",
+                    "type": "uint32"
+                }
+            ]
+        },
+        {
+            "name": "nonunique",
+            "base": "",
+            "fields": []
+        },
+        {
+            "name": "setup",
+            "base": "",
+            "fields": []
+        },
+        {
+            "name": "tuple_string_uint32",
+            "base": "",
+            "fields": [
+                {
+                    "name": "field_0",
+                    "type": "string"
+                },
+                {
+                    "name": "field_1",
+                    "type": "uint32"
+                }
+            ]
+        },
+        {
+            "name": "update",
+            "base": "",
+            "fields": []
+        },
+        {
+            "name": "updateerr1",
+            "base": "",
+            "fields": []
+        },
+        {
+            "name": "updateerr2",
+            "base": "",
+            "fields": []
+        }
+    ],
+    "actions": [
+        {
+            "name": "get",
+            "type": "get",
+            "ricardian_contract": ""
+        },
+        {
+            "name": "iteration",
+            "type": "iteration",
+            "ricardian_contract": ""
+        },
+        {
+            "name": "nonunique",
+            "type": "nonunique",
+            "ricardian_contract": ""
+        },
+        {
+            "name": "setup",
+            "type": "setup",
+            "ricardian_contract": ""
+        },
+        {
+            "name": "update",
+            "type": "update",
+            "ricardian_contract": ""
+        },
+        {
+            "name": "updateerr1",
+            "type": "updateerr1",
+            "ricardian_contract": ""
+        },
+        {
+            "name": "updateerr2",
+            "type": "updateerr2",
+            "ricardian_contract": ""
+        }
+    ],
+    "tables": [],
+    "kv_tables": {
+        "testtable": {
+            "type": "my_struct",
+            "primary_index": {
+                "name": "primary",
+                "type": "name"
+            },
+            "secondary_indices": {
+                "foo": {
+                    "type": "string"
+                },
+                "bar": {
+                    "type": "uint64"
+                }
+            }
+        }
+    }
+})";
+
 std::string string_to_hex(const std::string& s) {
     std::string result;
     uint8_t size = s.size();
@@ -314,10 +451,12 @@ void check_types() {
     auto token = check_context(context, abieos_string_to_name(context, "eosio.token"));
     auto testAbiName = check_context(context, abieos_string_to_name(context, "test.abi"));
     auto testHexAbiName = check_context(context, abieos_string_to_name(context, "test.hex"));
+    auto testKvAbiName = check_context(context, abieos_string_to_name(context, "testkv.abi"));
     check_context(context, abieos_set_abi(context, 0, transactionAbi));
     check_context(context, abieos_set_abi_hex(context, token, tokenHexAbi));
     check_context(context, abieos_set_abi(context, testAbiName, testAbi));
     check_context(context, abieos_set_abi_hex(context, testHexAbiName, testHexAbi));
+    check_context(context, abieos_set_abi(context, testKvAbiName, testKvTablesAbi));
 
     int next_id = 0;
     auto write_corpus = [&](bool abi_is_bin, uint8_t operation, uint64_t contract, eosio::input_stream abi,
@@ -924,6 +1063,10 @@ void check_types() {
 
     testWith(testAbiName);
     testWith(testHexAbiName);
+
+    std::string table_def = check_context(context, abieos_get_kv_table_def(context, testKvAbiName, abieos_string_to_name(context, "testtable")));
+    if (table_def != R"({"type":"my_struct","primary_index":{"name":"primary","type":"name"},"secondary_indices":{"bar":{"type":"uint64"},"foo":{"type":"string"}}})")
+        throw std::runtime_error("mismatch");
 
     abieos_destroy(context);
 }


### PR DESCRIPTION
This PR add kv_tables to the ABI and a new function `abieos_get_kv_table_def()`to get the ABI definition of a given kv table.