### PR TITLE
erase old version abi before insert new version abi when set abi

### DIFF
--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -111,7 +111,9 @@ extern "C" abieos_bool abieos_set_abi(abieos_context* context, uint64_t contract
             return set_error(context, std::move(error));
         abieos::abi c;
         convert(def, c);
-        context->contracts.insert({name{contract}, std::move(c)});
+        const name key {contract};
+        context->contracts.erase(key);
+        context->contracts.insert({key, std::move(c)});
         return true;
     });
 }
@@ -132,7 +134,9 @@ extern "C" abieos_bool abieos_set_abi_bin(abieos_context* context, uint64_t cont
         from_bin(def, stream);
         abieos::abi c;
         convert(def, c);
-        context->contracts.insert({name{contract}, std::move(c)});
+        const name key {contract};
+        context->contracts.erase(key);
+        context->contracts.insert({key, std::move(c)});
         return true;
     });
 }


### PR DESCRIPTION
Because element keys in a map are unique, the insertion operation checks whether each inserted element has a key equivalent to the one of an element already in the container, and if so, the element is not inserted. So when we set a contract of new version, we must erase old version first. Otherwise the new contract is not inserted, and the old contract is still in context.