### PR TITLE
Add abi conversion json vs bin 

### DIFF
--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <functional>
-#include <string>
-#include <map>
-#include <vector>
-#include <variant>
-#include "types.hpp"
 #include "name.hpp"
+#include "types.hpp"
+#include <functional>
+#include <map>
+#include <string>
+#include <variant>
+#include <vector>
 
 namespace eosio {
 
@@ -24,7 +24,7 @@ enum class abi_error {
 };
 
 constexpr inline std::string_view convert_abi_error(eosio::abi_error e) {
-   switch(e) {
+   switch (e) {
       case abi_error::no_error: return "No error";
       case abi_error::recursion_limit_reached: return "Recursion limit reached";
       case abi_error::invalid_nesting: return "Invalid nesting";
@@ -42,13 +42,13 @@ struct abi_serializer;
 
 template <typename T>
 struct might_not_exist {
-    T value{};
+   T value{};
 };
 
 template <typename T, typename S>
 void from_bin(might_not_exist<T>& obj, S& stream) {
-    if (stream.remaining())
-        return from_bin(obj.value, stream);
+   if (stream.remaining())
+      return from_bin(obj.value, stream);
 }
 
 template <typename T, typename S>
@@ -58,7 +58,7 @@ void to_bin(const might_not_exist<T>& obj, S& stream) {
 
 template <typename T, typename S>
 void from_json(might_not_exist<T>& obj, S& stream) {
-    return from_json(obj.value, stream);
+   return from_json(obj.value, stream);
 }
 
 template <typename T, typename S>
@@ -69,69 +69,69 @@ void to_json(const might_not_exist<T>& val, S& stream) {
 using abi_extensions_type = std::vector<std::pair<uint16_t, std::vector<char>>>;
 
 struct type_def {
-    std::string new_type_name{};
-    std::string type{};
+   std::string new_type_name{};
+   std::string type{};
 };
 
 EOSIO_REFLECT(type_def, new_type_name, type);
 
 struct field_def {
-    std::string name{};
-    std::string type{};
+   std::string name{};
+   std::string type{};
 };
 
 EOSIO_REFLECT(field_def, name, type);
 
 struct struct_def {
-    std::string name{};
-    std::string base{};
-    std::vector<field_def> fields{};
+   std::string            name{};
+   std::string            base{};
+   std::vector<field_def> fields{};
 };
 
 EOSIO_REFLECT(struct_def, name, base, fields);
 
 struct action_def {
-    eosio::name name{};
-    std::string type{};
-    std::string ricardian_contract{};
+   eosio::name name{};
+   std::string type{};
+   std::string ricardian_contract{};
 };
 
 EOSIO_REFLECT(action_def, name, type, ricardian_contract);
 
 struct table_def {
-    eosio::name name{};
-    std::string index_type{};
-    std::vector<std::string> key_names{};
-    std::vector<std::string> key_types{};
-    std::string type{};
+   eosio::name              name{};
+   std::string              index_type{};
+   std::vector<std::string> key_names{};
+   std::vector<std::string> key_types{};
+   std::string              type{};
 };
 
 EOSIO_REFLECT(table_def, name, index_type, key_names, key_types, type);
 
 struct clause_pair {
-    std::string id{};
-    std::string body{};
+   std::string id{};
+   std::string body{};
 };
 
 EOSIO_REFLECT(clause_pair, id, body);
 
 struct error_message {
-    uint64_t error_code{};
-    std::string error_msg{};
+   uint64_t    error_code{};
+   std::string error_msg{};
 };
 
 EOSIO_REFLECT(error_message, error_code, error_msg);
 
 struct variant_def {
-    std::string name{};
-    std::vector<std::string> types{};
+   std::string              name{};
+   std::vector<std::string> types{};
 };
 
 EOSIO_REFLECT(variant_def, name, types);
 
 struct action_result_def {
-    eosio::name name{};
-    std::string result_type{};
+   eosio::name name{};
+   std::string result_type{};
 };
 
 EOSIO_REFLECT(action_result_def, name, result_type);
@@ -150,25 +150,25 @@ struct secondary_index_def {
 EOSIO_REFLECT(secondary_index_def, type);
 
 struct kv_table_entry_def {
-   std::string type;
-   primary_key_index_def primary_index;
+   std::string                                type;
+   primary_key_index_def                      primary_index;
    std::map<eosio::name, secondary_index_def> secondary_indices;
 };
 
 EOSIO_REFLECT(kv_table_entry_def, type, primary_index, secondary_indices);
 
 struct abi_def {
-    std::string version{};
-    std::vector<type_def> types{};
-    std::vector<struct_def> structs{};
-    std::vector<action_def> actions{};
-    std::vector<table_def> tables{};
-    std::vector<clause_pair> ricardian_clauses{};
-    std::vector<error_message> error_messages{};
-    abi_extensions_type abi_extensions{};
-    might_not_exist<std::vector<variant_def>> variants{};
-    might_not_exist<std::vector<action_result_def>> action_results{};
-    might_not_exist<std::map<eosio::name, kv_table_entry_def>> kv_tables{};
+   std::string                                                version{};
+   std::vector<type_def>                                      types{};
+   std::vector<struct_def>                                    structs{};
+   std::vector<action_def>                                    actions{};
+   std::vector<table_def>                                     tables{};
+   std::vector<clause_pair>                                   ricardian_clauses{};
+   std::vector<error_message>                                 error_messages{};
+   abi_extensions_type                                        abi_extensions{};
+   might_not_exist<std::vector<variant_def>>                  variants{};
+   might_not_exist<std::vector<action_result_def>>            action_results{};
+   might_not_exist<std::map<eosio::name, kv_table_entry_def>> kv_tables{};
 };
 
 EOSIO_REFLECT(abi_def, version, types, structs, actions, tables, ricardian_clauses, error_messages, abi_extensions,
@@ -177,72 +177,87 @@ EOSIO_REFLECT(abi_def, version, types, structs, actions, tables, ricardian_claus
 struct abi_type;
 
 struct abi_field {
-    std::string name;
-    const abi_type* type;
+   std::string     name;
+   const abi_type* type;
 };
 
 struct abi_type {
-    std::string name;
+   std::string name;
 
-    struct builtin {};
-    using alias_def = std::string;
-    struct alias { abi_type* type; };
-    struct optional { abi_type* type; };
-    struct extension { abi_type* type; };
-    struct array { abi_type* type; };
-    struct struct_ {
-        abi_type* base = nullptr;
-        std::vector<abi_field> fields;
-    };
-    using variant = std::vector<abi_field>;
-    std::variant<builtin, const alias_def*, const struct_def*, const variant_def*, alias, optional, extension, array, struct_, variant> _data;
-    const abi_serializer* ser = nullptr;
+   struct builtin {};
+   using alias_def = std::string;
+   struct alias {
+      abi_type* type;
+   };
+   struct optional {
+      abi_type* type;
+   };
+   struct extension {
+      abi_type* type;
+   };
+   struct array {
+      abi_type* type;
+   };
+   struct struct_ {
+      abi_type*              base = nullptr;
+      std::vector<abi_field> fields;
+   };
+   using variant = std::vector<abi_field>;
+   std::variant<builtin, const alias_def*, const struct_def*, const variant_def*, alias, optional, extension, array,
+                struct_, variant>
+                         _data;
+   const abi_serializer* ser = nullptr;
 
-    template<typename T>
-    abi_type(std::string name, T&& arg, const abi_serializer* ser)
-        : name(std::move(name)), _data(std::forward<T>(arg)), ser(ser) {}
-    abi_type(const abi_type&) = delete;
-    abi_type& operator=(const abi_type&) = delete;
+   template <typename T>
+   abi_type(std::string name, T&& arg, const abi_serializer* ser)
+       : name(std::move(name)), _data(std::forward<T>(arg)), ser(ser) {}
+   abi_type(const abi_type&) = delete;
+   abi_type& operator=(const abi_type&) = delete;
 
-    // result<void> json_to_bin(std::vector<char>& bin, std::string_view json);
-    const abi_type* optional_of() const {
-       if(auto* t = std::get_if<optional>(&_data)) return t->type;
-       else return nullptr;
-    }
-    const abi_type* extension_of() const {
-       if(auto* t = std::get_if<extension>(&_data)) return t->type;
-       else return nullptr;
-    }
-    const abi_type* array_of() const {
-       if(auto* t = std::get_if<array>(&_data)) return t->type;
-       else return nullptr;
-    }
-    const struct_* as_struct() const {
-       return std::get_if<struct_>(&_data);
-    }
-    const variant* as_variant() const {
-       return std::get_if<variant>(&_data);
-    }
+   // result<void> json_to_bin(std::vector<char>& bin, std::string_view json);
+   const abi_type* optional_of() const {
+      if (auto* t = std::get_if<optional>(&_data))
+         return t->type;
+      else
+         return nullptr;
+   }
+   const abi_type* extension_of() const {
+      if (auto* t = std::get_if<extension>(&_data))
+         return t->type;
+      else
+         return nullptr;
+   }
+   const abi_type* array_of() const {
+      if (auto* t = std::get_if<array>(&_data))
+         return t->type;
+      else
+         return nullptr;
+   }
+   const struct_* as_struct() const { return std::get_if<struct_>(&_data); }
+   const variant* as_variant() const { return std::get_if<variant>(&_data); }
 
-    std::string bin_to_json(input_stream& bin, std::function<void()> f = []{}) const;
-    std::vector<char> json_to_bin(std::string_view json, std::function<void()> f = []{}) const;
-    std::vector<char> json_to_bin_reorderable(std::string_view json, std::function<void()> f = []{}) const;
+   std::string bin_to_json(
+         input_stream& bin, std::function<void()> f = [] {}) const;
+   std::vector<char> json_to_bin(
+         std::string_view json, std::function<void()> f = [] {}) const;
+   std::vector<char> json_to_bin_reorderable(
+         std::string_view json, std::function<void()> f = [] {}) const;
 };
 
 struct abi {
-    std::map<eosio::name, std::string> action_types;
-    std::map<eosio::name, std::string> table_types;
-    std::map<eosio::name, std::string> kv_tables;
-    std::map<std::string, abi_type> abi_types;
-    std::map<eosio::name, std::string> action_result_types;
-    const abi_type* get_type(const std::string& name);
+   std::map<eosio::name, std::string> action_types;
+   std::map<eosio::name, std::string> table_types;
+   std::map<eosio::name, std::string> kv_tables;
+   std::map<std::string, abi_type>    abi_types;
+   std::map<eosio::name, std::string> action_result_types;
+   const abi_type*                    get_type(const std::string& name);
 
-    // Adds a type to the abi.  Has no effect if the type is already present.
-    // If the type is a struct, all members will be added recursively.
-    // Exception Safety: basic. If add_type fails, some objects may have
-    // an incomplete list of fields.
-    template<typename T>
-    abi_type* add_type();
+   // Adds a type to the abi.  Has no effect if the type is already present.
+   // If the type is a struct, all members will be added recursively.
+   // Exception Safety: basic. If add_type fails, some objects may have
+   // an incomplete list of fields.
+   template <typename T>
+   abi_type* add_type();
 };
 
 void convert(const abi_def& def, abi&);
@@ -254,72 +269,74 @@ extern const abi_serializer* const array_abi_serializer;
 extern const abi_serializer* const extension_abi_serializer;
 extern const abi_serializer* const optional_abi_serializer;
 
-template<typename T>
+template <typename T>
 auto add_type(abi& a, T*) -> std::enable_if_t<reflection::has_for_each_field_v<T>, abi_type*> {
-   std::string name = get_type_name((T*)nullptr);
+   std::string name      = get_type_name((T*)nullptr);
    auto [iter, inserted] = a.abi_types.try_emplace(name, name, abi_type::struct_{}, object_abi_serializer);
-   if(!inserted)
+   if (!inserted)
       return &iter->second;
    auto& s = std::get<abi_type::struct_>(iter->second._data);
-   for_each_field<T>([&](const char* name, auto&& member){
+   for_each_field<T>([&](const char* name, auto&& member) {
       auto member_type = a.add_type<std::decay_t<decltype(member((T*)nullptr))>>();
-      s.fields.push_back({name, member_type});
+      s.fields.push_back({ name, member_type });
    });
    return &iter->second;
 }
 
-template<typename T>
+template <typename T>
 auto add_type(abi& a, T* t) -> std::enable_if_t<!reflection::has_for_each_field_v<T>, abi_type*> {
    auto iter = a.abi_types.find(get_type_name(t));
-   check( iter != a.abi_types.end(),
-      convert_abi_error(abi_error::unknown_type) );
+   check(iter != a.abi_types.end(), convert_abi_error(abi_error::unknown_type));
    return &iter->second;
 }
 
-template<typename T>
+template <typename T>
 abi_type* add_type(abi& a, std::vector<T>*) {
    auto element_type = a.add_type<T>();
    check(!(element_type->optional_of() || element_type->array_of() || element_type->extension_of()),
-      convert_abi_error(abi_error::invalid_nesting));
-   std::string name = get_type_name((std::vector<T>*)nullptr);
-   auto [iter, inserted] = a.abi_types.try_emplace(name, name, abi_type::array{element_type}, array_abi_serializer);
+         convert_abi_error(abi_error::invalid_nesting));
+   std::string name      = get_type_name((std::vector<T>*)nullptr);
+   auto [iter, inserted] = a.abi_types.try_emplace(name, name, abi_type::array{ element_type }, array_abi_serializer);
    return &iter->second;
 }
 
-template<typename... T>
+template <typename... T>
 abi_type* add_type(abi& a, std::variant<T...>*) {
    abi_type::variant types;
-   ([&](auto* t) {
-      auto type = add_type(a, t);
-      types.push_back({type->name, type});
-   }((T*)nullptr), ...);
+   (
+         [&](auto* t) {
+            auto type = add_type(a, t);
+            types.push_back({ type->name, type });
+         }((T*)nullptr),
+         ...);
    std::string name = get_type_name((std::variant<T...>*)nullptr);
 
    auto [iter, inserted] = a.abi_types.try_emplace(name, name, std::move(types), variant_abi_serializer);
    return &iter->second;
 }
 
-template<typename T>
+template <typename T>
 abi_type* add_type(abi& a, std::optional<T>*) {
    auto element_type = a.add_type<T>();
    check(!(element_type->optional_of() || element_type->array_of() || element_type->extension_of()),
-      convert_abi_error(abi_error::invalid_nesting));
+         convert_abi_error(abi_error::invalid_nesting));
    std::string name = get_type_name((std::optional<T>*)nullptr);
-   auto [iter, inserted] = a.abi_types.try_emplace(name, name, abi_type::optional{element_type}, optional_abi_serializer);
+   auto [iter, inserted] =
+         a.abi_types.try_emplace(name, name, abi_type::optional{ element_type }, optional_abi_serializer);
    return &iter->second;
 }
 
-template<typename T>
+template <typename T>
 abi_type* add_type(abi& a, might_not_exist<T>*) {
    auto element_type = a.add_type<T>();
-   check(!element_type->extension_of(),
-      convert_abi_error(abi_error::invalid_nesting));
+   check(!element_type->extension_of(), convert_abi_error(abi_error::invalid_nesting));
    std::string name = element_type->name + "$";
-   auto [iter, inserted] = a.abi_types.try_emplace(name, name, abi_type::extension{element_type}, extension_abi_serializer);
+   auto [iter, inserted] =
+         a.abi_types.try_emplace(name, name, abi_type::extension{ element_type }, extension_abi_serializer);
    return &iter->second;
 }
 
-template<typename T>
+template <typename T>
 abi_type* abi::add_type() {
    using eosio::add_type;
    return add_type(*this, (T*)nullptr);
@@ -356,4 +373,4 @@ void to_json(const abi_def& def, S& stream) {
    }
    stream.write('}');
 }
-}
+} // namespace eosio

--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -61,6 +61,11 @@ void from_json(might_not_exist<T>& obj, S& stream) {
     return from_json(obj.value, stream);
 }
 
+template <typename T, typename S>
+void to_json(might_not_exist<T>& obj, S& stream) {
+   return to_json(obj.value, stream);
+}
+
 using abi_extensions_type = std::vector<std::pair<uint16_t, std::vector<char>>>;
 
 struct type_def {

--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -326,13 +326,13 @@ abi_type* abi::add_type() {
 }
 
 template <typename T, typename S>
-void to_json_write_helper(const T& type, const std::string_view type_name, const bool has_comma, S& stream) {
-   if (has_comma) {
+void to_json_write_helper(const T& field, const std::string_view field_name, const bool need_comma, S& stream) {
+   if (need_comma) {
       stream.write(',');
    }
-   to_json(type_name, stream);
+   to_json(field_name, stream);
    stream.write(':');
-   to_json(type, stream);
+   to_json(field, stream);
 }
 
 template <typename S>
@@ -356,6 +356,4 @@ void to_json(const abi_def& def, S& stream) {
    }
    stream.write('}');
 }
-
-
 }

--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -325,77 +325,34 @@ abi_type* abi::add_type() {
    return add_type(*this, (T*)nullptr);
 }
 
-template <typename S>
-void to_json(const abi_extensions_type& ext_type, S& stream) {
-   stream.write('[');
-   bool first = true;
-   for(const auto& p : ext_type) {
-      if (first) {
-         first = false;
-      } else {
-         stream.write(',');
-      }
-      stream.write('{');
-      to_json(p.first, stream);
-      stream.write(':');
-      to_json(p.second, stream);
-      stream.write('}');
+template <typename T, typename S>
+void to_json_write_helper(const T& type, const std::string_view type_name, const bool has_comma, S& stream) {
+   if (has_comma) {
+      stream.write(',');
    }
-   stream.write(']');
+   to_json(type_name, stream);
+   stream.write(':');
+   to_json(type, stream);
 }
 
 template <typename S>
 void to_json(const abi_def& def, S& stream) {
    stream.write('{');
-   to_json("version", stream);
-   stream.write(':');
-   to_json(def.version, stream);
-   stream.write(',');
-   to_json("types", stream);
-   stream.write(':');
-   to_json(def.types, stream);
-   stream.write(',');
-   to_json("structs", stream);
-   stream.write(':');
-   to_json(def.structs, stream);
-   stream.write(',');
-   to_json("actions", stream);
-   stream.write(':');
-   to_json(def.actions, stream);
-   stream.write(',');
-   to_json("tables", stream);
-   stream.write(':');
-   to_json(def.tables, stream);
-   stream.write(',');
-
-   to_json("ricardian_clauses", stream);
-   stream.write(':');
-   to_json(def.ricardian_clauses, stream);
-   stream.write(',');
-   to_json("error_messages", stream);
-   stream.write(':');
-   to_json(def.error_messages, stream);
-   stream.write(',');
-   to_json("abi_extensions", stream);
-   stream.write(':');
-   to_json(def.abi_extensions, stream);
+   to_json_write_helper(def.version, "version", false, stream);
+   to_json_write_helper(def.types, "types", true, stream);
+   to_json_write_helper(def.structs, "structs", true, stream);
+   to_json_write_helper(def.actions, "actions", true, stream);
+   to_json_write_helper(def.tables, "tables", true, stream);
+   to_json_write_helper(def.ricardian_clauses, "ricardian_clauses", true, stream);
+   to_json_write_helper(def.error_messages, "error_messages", true, stream);
    if (!def.variants.value.empty()) {
-      stream.write(',');
-      to_json("variants", stream);
-      stream.write(':');
-      to_json(def.variants.value, stream);
+      to_json_write_helper(def.variants.value, "variants", true, stream);
    }
    if (!def.action_results.value.empty()) {
-      stream.write(',');
-      to_json("action_results", stream);
-      stream.write(':');
-      to_json(def.action_results.value, stream);
+      to_json_write_helper(def.action_results.value, "action_results", true, stream);
    }
    if (!def.kv_tables.value.empty()) {
-      stream.write(',');
-      to_json("kv_tables", stream);
-      stream.write(':');
-      to_json(def.kv_tables.value, stream);
+      to_json_write_helper(def.kv_tables.value, "kv_tables", true, stream);
    }
    stream.write('}');
 }

--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -62,8 +62,8 @@ void from_json(might_not_exist<T>& obj, S& stream) {
 }
 
 template <typename T, typename S>
-void to_json(might_not_exist<T>& obj, S& stream) {
-   return to_json(obj.value, stream);
+void to_json(const might_not_exist<T>& val, S& stream) {
+   return to_json(val.value, stream);
 }
 
 using abi_extensions_type = std::vector<std::pair<uint16_t, std::vector<char>>>;
@@ -324,5 +324,81 @@ abi_type* abi::add_type() {
    using eosio::add_type;
    return add_type(*this, (T*)nullptr);
 }
+
+template <typename S>
+void to_json(const abi_extensions_type& ext_type, S& stream) {
+   stream.write('[');
+   bool first = true;
+   for(const auto& p : ext_type) {
+      if (first) {
+         first = false;
+      } else {
+         stream.write(',');
+      }
+      stream.write('{');
+      to_json(p.first, stream);
+      stream.write(':');
+      to_json(p.second, stream);
+      stream.write('}');
+   }
+   stream.write(']');
+}
+
+template <typename S>
+void to_json(const abi_def& def, S& stream) {
+   stream.write('{');
+   to_json("version", stream);
+   stream.write(':');
+   to_json(def.version, stream);
+   stream.write(',');
+   to_json("types", stream);
+   stream.write(':');
+   to_json(def.types, stream);
+   stream.write(',');
+   to_json("structs", stream);
+   stream.write(':');
+   to_json(def.structs, stream);
+   stream.write(',');
+   to_json("actions", stream);
+   stream.write(':');
+   to_json(def.actions, stream);
+   stream.write(',');
+   to_json("tables", stream);
+   stream.write(':');
+   to_json(def.tables, stream);
+   stream.write(',');
+
+   to_json("ricardian_clauses", stream);
+   stream.write(':');
+   to_json(def.ricardian_clauses, stream);
+   stream.write(',');
+   to_json("error_messages", stream);
+   stream.write(':');
+   to_json(def.error_messages, stream);
+   stream.write(',');
+   to_json("abi_extensions", stream);
+   stream.write(':');
+   to_json(def.abi_extensions, stream);
+   if (!def.variants.value.empty()) {
+      stream.write(',');
+      to_json("variants", stream);
+      stream.write(':');
+      to_json(def.variants.value, stream);
+   }
+   if (!def.action_results.value.empty()) {
+      stream.write(',');
+      to_json("action_results", stream);
+      stream.write(':');
+      to_json(def.action_results.value, stream);
+   }
+   if (!def.kv_tables.value.empty()) {
+      stream.write(',');
+      to_json("kv_tables", stream);
+      stream.write(':');
+      to_json(def.kv_tables.value, stream);
+   }
+   stream.write('}');
+}
+
 
 }

--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -260,7 +260,7 @@ extern "C" const char* abieos_bin_to_json(abieos_context* context, uint64_t cont
         }
         auto t = contract_it->second.get_type(type);
         eosio::input_stream bin{data, size};
-           context->result_str = t->bin_to_json(bin);
+        context->result_str = t->bin_to_json(bin);
         if (bin.pos != bin.end)
             throw std::runtime_error("Extra data");
         return context->result_str.c_str();

--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -191,12 +191,13 @@ extern "C" const char* abieos_get_kv_table_def(abieos_context* context, uint64_t
         auto table_it = c.kv_tables.find(name{table});
         if (table_it == c.kv_tables.end())
             throw std::runtime_error("contract \"" + eosio::name_to_string(contract) + "\" does not have kv table \"" +
-                                        eosio::name_to_string(table) + "\"");
+                                     eosio::name_to_string(table) + "\"");
         return table_it->second.c_str();
     });
 }
 
-extern "C" const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract, uint64_t action_result) {
+extern "C" const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract,
+                                                         uint64_t action_result) {
     return handle_exceptions(context, nullptr, [&] {
         auto contract_it = context->contracts.find(::abieos::name{contract});
         if (contract_it == context->contracts.end())
@@ -205,8 +206,8 @@ extern "C" const char* abieos_get_type_for_action_result(abieos_context* context
 
         auto action_result_it = c.action_result_types.find(name{action_result});
         if (action_result_it == c.action_result_types.end())
-            throw std::runtime_error("contract \"" + eosio::name_to_string(contract) + "\" does not have action_result \"" +
-                                     eosio::name_to_string(action_result) + "\"");
+            throw std::runtime_error("contract \"" + eosio::name_to_string(contract) +
+                                     "\" does not have action_result \"" + eosio::name_to_string(action_result) + "\"");
         return action_result_it->second.c_str();
     });
 }
@@ -282,43 +283,42 @@ extern "C" const char* abieos_hex_to_json(abieos_context* context, uint64_t cont
     });
 }
 
-extern "C" abieos_bool abieos_abi_json_to_bin(abieos_context* context, const char* abi_json)
-{
-   fix_null_str(abi_json);
-   return handle_exceptions(context, false, [&] {
-      std::string abi_copy{abi_json};
-      eosio::json_token_stream json_stream(abi_copy.data());
-      abi_def def{};
-      std::string error;
-      from_json(def, json_stream);
-      if (!check_abi_version(def.version, error)) {
-         return set_error(context, std::move(error));
-      }
-      context->result_bin = convert_to_bin(def);
-      return true;
-   });
+extern "C" abieos_bool abieos_abi_json_to_bin(abieos_context* context, const char* abi_json) {
+    fix_null_str(abi_json);
+    return handle_exceptions(context, false, [&] {
+        std::string abi_copy{abi_json};
+        eosio::json_token_stream json_stream(abi_copy.data());
+        abi_def def{};
+        std::string error;
+        from_json(def, json_stream);
+        if (!check_abi_version(def.version, error)) {
+            return set_error(context, std::move(error));
+        }
+        context->result_bin = convert_to_bin(def);
+        return true;
+    });
 }
 
-extern "C" const char* abieos_abi_bin_to_json(abieos_context* context, const char* abi_bin_data, const size_t abi_bin_data_size)
-{
-   return handle_exceptions(context, nullptr, [&]() -> const char* {
-      if (!abi_bin_data || abi_bin_data_size == 0) {
-         set_error(context, "no data");
-         return nullptr;
-      }
-      eosio::input_stream bin_stream{abi_bin_data, abi_bin_data_size};
-      abi_def def{};
-      from_bin(def, bin_stream);
-      std::string error;
-      if (!check_abi_version(def.version, error)) {
-         set_error(context, std::move(error));
-         return nullptr;
-      }
-      std::vector<char> bytes;
-      eosio::vector_stream byte_stream(bytes);
-      to_json(def, byte_stream);
+extern "C" const char* abieos_abi_bin_to_json(abieos_context* context, const char* abi_bin_data,
+                                              const size_t abi_bin_data_size) {
+    return handle_exceptions(context, nullptr, [&]() -> const char* {
+        if (!abi_bin_data || abi_bin_data_size == 0) {
+            set_error(context, "no data");
+            return nullptr;
+        }
+        eosio::input_stream bin_stream{abi_bin_data, abi_bin_data_size};
+        abi_def def{};
+        from_bin(def, bin_stream);
+        std::string error;
+        if (!check_abi_version(def.version, error)) {
+            set_error(context, std::move(error));
+            return nullptr;
+        }
+        std::vector<char> bytes;
+        eosio::vector_stream byte_stream(bytes);
+        to_json(def, byte_stream);
 
-      context->result_str.assign(bytes.begin(), bytes.end());
-      return context->result_str.c_str();
-   });
+        context->result_str.assign(bytes.begin(), bytes.end());
+        return context->result_str.c_str();
+    });
 }

--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -260,7 +260,7 @@ extern "C" const char* abieos_bin_to_json(abieos_context* context, uint64_t cont
         }
         auto t = contract_it->second.get_type(type);
         eosio::input_stream bin{data, size};
-        context->result_str = t->bin_to_json(bin);
+           context->result_str = t->bin_to_json(bin);
         if (bin.pos != bin.end)
             throw std::runtime_error("Extra data");
         return context->result_str.c_str();
@@ -299,34 +299,26 @@ extern "C" abieos_bool abieos_abi_json_to_bin(abieos_context* context, const cha
    });
 }
 
-extern "C" abieos_bool abieos_abi_bin_to_json(abieos_context* context, const char* abi_bin_data, const size_t abi_bin_data_size)
+extern "C" const char* abieos_abi_bin_to_json(abieos_context* context, const char* abi_bin_data, const size_t abi_bin_data_size)
 {
-   return handle_exceptions(context, false, [&] {
+   return handle_exceptions(context, nullptr, [&]() -> const char* {
       if (!abi_bin_data || abi_bin_data_size == 0) {
-         return set_error(context, "no data");
+         set_error(context, "no data");
+         return nullptr;
       }
       eosio::input_stream bin_stream{abi_bin_data, abi_bin_data_size};
       abi_def def{};
       from_bin(def, bin_stream);
       std::string error;
       if (!check_abi_version(def.version, error)) {
-         return set_error(context, std::move(error));
+         set_error(context, std::move(error));
+         return nullptr;
       }
       std::vector<char> bytes;
       eosio::vector_stream byte_stream(bytes);
       to_json(def, byte_stream);
 
-/*      context->result_str = byte_stream;
-*/      return true;
+      context->result_str.assign(bytes.begin(), bytes.end());
+      return context->result_str.c_str();
    });
 }
-
-extern "C" abieos_bool abieos_abi_json_to_hex(abieos_context* context, const char* abi_json)
-{
-}
-
-extern "C" abieos_bool abieos_abi_hex_to_json(abieos_context* context, const char* abi_hex_data)
-{
-
-}
-

--- a/src/abieos.h
+++ b/src/abieos.h
@@ -52,12 +52,12 @@ const char* abieos_get_type_for_action(abieos_context* context, uint64_t contrac
 // to retrieve error.
 const char* abieos_get_type_for_table(abieos_context* context, uint64_t contract, uint64_t table);
 
-// Get the definition for a kv table in json. The context owns the returned memory. Returns null on error; use abieos_get_error
-// to retrieve error.
+// Get the definition for a kv table in json. The context owns the returned memory. Returns null on error; use
+// abieos_get_error to retrieve error.
 const char* abieos_get_kv_table_def(abieos_context* context, uint64_t contract, uint64_t table);
 
-// Get the type name for an action_result. The context owns the returned memory. Returns null on error; use abieos_get_error
-// to retrieve error.
+// Get the type name for an action_result. The context owns the returned memory. Returns null on error; use
+// abieos_get_error to retrieve error.
 const char* abieos_get_type_for_action_result(abieos_context* context, uint64_t contract, uint64_t action_result);
 
 // Convert json to binary. Use abieos_get_bin_* to retrieve result. Returns false on error.
@@ -79,7 +79,8 @@ const char* abieos_hex_to_json(abieos_context* context, uint64_t contract, const
 // Convert abi json to bin, Use abieos_get_bin_* to retrieve result. Returns false on error.
 abieos_bool abieos_abi_json_to_bin(abieos_context* context, const char* json);
 
-// Convert abi bin to json, The context.result_str has the result, Returns null on error; use abieos_get_error to retrieve
+// Convert abi bin to json, The context.result_str has the result, Returns null on error; use abieos_get_error to
+// retrieve
 const char* abieos_abi_bin_to_json(abieos_context* context, const char* abi_bin_data, const size_t abi_bin_data_size);
 
 #ifdef __cplusplus

--- a/src/abieos.h
+++ b/src/abieos.h
@@ -76,17 +76,11 @@ const char* abieos_bin_to_json(abieos_context* context, uint64_t contract, const
 // error.
 const char* abieos_hex_to_json(abieos_context* context, uint64_t contract, const char* type, const char* hex);
 
-// Convert abi json to bin
+// Convert abi json to bin, Use abieos_get_bin_* to retrieve result. Returns false on error.
 abieos_bool abieos_abi_json_to_bin(abieos_context* context, const char* json);
 
-// Convert abi bin to json
-abieos_bool abieos_abi_bin_to_json(abieos_context* context, const char* abi_bin_data, const size_t abi_bin_data_size);
-
-// Convert abi json to hex
-abieos_bool abieos_abi_json_to_hex(abieos_context* context, const char* json);
-
-// Convert abi hex to json
-abieos_bool abieos_abi_hex_to_json(abieos_context* context, const char* hex_data);
+// Convert abi bin to json, The context.result_str has the result, Returns null on error; use abieos_get_error to retrieve
+const char* abieos_abi_bin_to_json(abieos_context* context, const char* abi_bin_data, const size_t abi_bin_data_size);
 
 #ifdef __cplusplus
 }

--- a/src/abieos.h
+++ b/src/abieos.h
@@ -76,6 +76,18 @@ const char* abieos_bin_to_json(abieos_context* context, uint64_t contract, const
 // error.
 const char* abieos_hex_to_json(abieos_context* context, uint64_t contract, const char* type, const char* hex);
 
+// Convert abi json to bin
+abieos_bool abieos_abi_json_to_bin(abieos_context* context, const char* json);
+
+// Convert abi bin to json
+abieos_bool abieos_abi_bin_to_json(abieos_context* context, const char* abi_bin_data, const size_t abi_bin_data_size);
+
+// Convert abi json to hex
+abieos_bool abieos_abi_json_to_hex(abieos_context* context, const char* json);
+
+// Convert abi hex to json
+abieos_bool abieos_abi_hex_to_json(abieos_context* context, const char* hex_data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1135,11 +1135,10 @@ void test_abi_kv_table()
       all_abi_def.tables.push_back(eosio::table_def{eosio::name{"tname1"}, "idx_type1", {"k_name_1"}, {"k_type1"}, {"t_type1"}});
       all_abi_def.ricardian_clauses.push_back(eosio::clause_pair{"cp_id_1", "cp_body_1"});
       all_abi_def.error_messages.push_back(eosio::error_message{1234567890, "msg1"});
-      // should std::pair needs to be supported? from_json does not support
-      // all_abi_def.abi_extensions.push_back({123, {'a', 'b'}});
+      // Ignore abi_extensions in to_json and from_json
       all_abi_def.variants.value.push_back(eosio::variant_def{"v_name1", {"v_type1"}});
       all_abi_def.action_results.value.push_back(eosio::action_result_def{eosio::name{"aname1"}, {"a_type1"}});
-      eosio::kv_table_entry_def kv_def{"kv_type1", eosio::primary_key_index_def{eosio::name{"pki1"}, "kv_type1"}};
+      eosio::kv_table_entry_def kv_def{"kv_type1", eosio::primary_key_index_def{eosio::name{"pki1"}, "kv_type1"}, {}};
       kv_def.secondary_indices[eosio::name{"sec2"}] = eosio::secondary_index_def{"sid2"};
       all_abi_def.kv_tables.value[eosio::name{"kv1"}] = kv_def;
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
+#include <iostream>
 
 inline const bool generate_corpus = false;
 
@@ -1071,10 +1072,28 @@ void check_types() {
     abieos_destroy(context);
 }
 
+void test_abi_kv_table()
+{
+   using namespace std;
+/*
+   abieos_context* abi_cnxt = abieos_create();
+
+   if (!abieos_set_abi(abi_cnxt, eosio::string_to_name("kv.table.abi"), testKvTablesAbi)) {
+      throw std::runtime_error("Failed to add abi testKvTablesAbi");
+   }
+
+
+   abieos_destroy(abi_cnxt);
+*/
+}
+
 int main() {
     try {
         check_types();
-        printf("\nok\n\n");
+        printf("\ncheck_types ok\n\n");
+
+        test_abi_kv_table();
+        printf("\ntest_abi_kv_table ok\n\n");
         return 0;
     } catch (std::exception& e) {
         printf("error: %s\n", e.what());


### PR DESCRIPTION
As of  `abieos` has lost the implicit ability to convert ABI's themselves between their JSON, binary and hex forms.  

Prior to this, the structure of a binary ABI could be defined by an ABI itself resulting in an implicit ability to achieve this use-case by loading the `ABI.abi` and processing the abi data as it it were transaction/action data.  

This task re-adds support for this use-case as explicit first class methods of abieos exposed through the C interface.  

These should use the existing conventions from `get_bin|hex` and `to_json` functions  

Note:
1. will perform clang_format after code logic review is done.
2. std::pair is not supported from from_json,  should add it for "abi_extensions_type"