### PR TITLE
remove object checking for may_not_exist

### DIFF
--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -362,9 +362,9 @@ void to_json(const abi_def& def, S& stream) {
    to_json_write_helper(def.tables, "tables", true, stream);
    to_json_write_helper(def.ricardian_clauses, "ricardian_clauses", true, stream);
    to_json_write_helper(def.error_messages, "error_messages", true, stream);
-   to_json_write_helper(def.variants.value.empty()? std::vector<variant_def>() : def.variants.value, "variants", true, stream);
-   to_json_write_helper(def.action_results.value.empty()? std::vector<action_result_def>() : def.action_results.value, "action_results", true, stream);
-   to_json_write_helper(def.kv_tables.value.empty() ? std::map<eosio::name, kv_table_entry_def>() : def.kv_tables.value, "kv_tables", true, stream);
+   to_json_write_helper(def.variants.value, "variants", true, stream);
+   to_json_write_helper(def.action_results.value, "action_results", true, stream);
+   to_json_write_helper(def.kv_tables.value, "kv_tables", true, stream);
    stream.write('}');
 }
 } // namespace eosio


### PR DESCRIPTION
Had wrong impression that may_not_exist is similar as optional, but it stores object instead. remove the unnecessary checking.