### PR TITLE
Remove database field from key_value_v0 struct and add payer

### DIFF
--- a/include/eosio/ship_protocol.hpp
+++ b/include/eosio/ship_protocol.hpp
@@ -603,13 +603,13 @@ namespace eosio { namespace ship_protocol {
    using contract_index_long_double = std::variant<contract_index_long_double_v0>;
 
    struct key_value_v0 {
-      eosio::name         database = {};
       eosio::name         contract = {};
       eosio::input_stream key      = {};
       eosio::input_stream value    = {};
+      eosio::name         payer    = {};
    };
 
-   EOSIO_REFLECT(key_value_v0, database, contract, key, value)
+   EOSIO_REFLECT(key_value_v0, contract, key, value, payer)
 
    using key_value = std::variant<key_value_v0>;
 


### PR DESCRIPTION
- Remove the database field from key_value_v0 struct, as this field would no longer be used.
- Also add the payer field.