### PR TITLE
Add to_bin opaque overload.

### DIFF
--- a/include/eosio/opaque.hpp
+++ b/include/eosio/opaque.hpp
@@ -67,6 +67,12 @@ class opaque_base {
    void from(S& stream) {
       eosio::from_bin(this->bin, stream);
    }
+
+  template <typename S>
+  void to_bin(S& stream) const {
+    eosio::to_bin(this->bin, stream);
+  }
+
 };
 
 template <typename T>
@@ -93,6 +99,7 @@ class opaque<std::vector<T>> : public opaque_base<std::vector<T>> {
       this->unpack_next(obj);
       return obj;
    }
+
 };
 
 template <typename T>
@@ -104,5 +111,10 @@ template <typename T, typename S>
 void from_bin(opaque<T>& obj, S& stream) {
    obj.from(stream);
 }
+
+  template <typename T, typename S>
+  void to_bin(const opaque<T>& obj, S& stream) {
+    obj.to_bin(stream);
+  }
 
 } // namespace eosio


### PR DESCRIPTION
Type opaque was missing the to_bin overload required for binary transformation. This patch fixes it.