### PR TITLE
EPE-522 Expose the Size value of the fixed_bytes object

### DIFF
--- a/include/eosio/fixed_bytes.hpp
+++ b/include/eosio/fixed_bytes.hpp
@@ -185,6 +185,10 @@ class fixed_bytes {
    constexpr const Word* data() const { return value.data(); }
    constexpr std::size_t size() const { return value.size(); }
    /**
+    * Get the Word storing capacity in the underlying data of the contained std::array
+    */
+   constexpr std::size_t capacity() const { return Size; }
+   /**
     * Get the contained std::array
     */
    constexpr const auto&                 get_array() const { return value; }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -925,6 +925,19 @@ void check_types() {
     testWith(testAbiName);
     testWith(testHexAbiName);
 
+    auto check_checksum_capacity = [&](const auto& checksum, size_t capacity, const char* msg) {
+        if(checksum.capacity() != capacity)
+            throw std::runtime_error(std::string{msg} + " capacity test failed");
+    };
+
+    check_checksum_capacity(eosio::checksum160(), 20, "checksum160");
+    check_checksum_capacity(eosio::checksum256(), 32, "checksum256");
+    check_checksum_capacity(eosio::checksum512(), 64, "checksum512");
+
+    check_checksum_capacity(eosio::checksum160({1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}), 20, "checksum160");
+    check_checksum_capacity(eosio::checksum256({1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}), 32, "checksum256");
+    check_checksum_capacity(eosio::checksum512({1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1}), 64, "checksum512");
+
     abieos_destroy(context);
 }
 


### PR DESCRIPTION
Added "capacity" method to fixed_bytes definition that returns the
"Size" template parameter value.