### PR TITLE
Opaque type - update documentantion for desearilization and increase maximum size of vectors

### DIFF
--- a/include/eosio/opaque.hpp
+++ b/include/eosio/opaque.hpp
@@ -55,8 +55,14 @@ class opaque_base {
    explicit opaque_base(const std::vector<char>& data) : bin(data) {}
    explicit opaque_base(input_stream strm) { eosio::from_bin(bin, strm); }
 
+   /**
+      @pre this->empty() should be false.
+   */
    void unpack(T& obj) { eosio::from_bin(obj, bin); }
 
+   /**
+      @pre this->empty() should be false.
+   */
    T unpack() {
       T obj;
       this->unpack(obj);
@@ -90,7 +96,7 @@ class opaque<std::vector<T>> : public opaque_base<std::vector<T>> {
 
    /** Determine the size of the vector to be unpacked.
 
-    @pre this->empty() should be false.
+      @pre this->empty() should be false.
    */
    uint64_t unpack_size() {
       uint64_t num;

--- a/include/eosio/opaque.hpp
+++ b/include/eosio/opaque.hpp
@@ -33,11 +33,13 @@ namespace eosio {
 ///   foo_type foo_value; 
 ///   from_bin(foo_value, serialized_foo_stream);
 ///   if (foo_value.field1 > 1 || foo_value.field2 == "meet_precondition") {
-///      auto sz = foo_value.field3.unpack_size();
-///      for (size_t i = 0; i < sz; ++i) {
-///         if (foo_value.field3.unpack_next() == "value_to_be_searched") {
-///            do_something_when_found();
-///            break;
+///      if(!foo_value.field3.empty()) {
+///         auto sz = foo_value.field3.unpack_size();
+///         for (size_t i = 0; i < sz; ++i) {
+///            if (foo_value.field3.unpack_next() == "value_to_be_searched") {
+///               do_something_when_found();
+///               break;
+///            }
 ///         }
 ///      }
 ///   }
@@ -86,9 +88,13 @@ class opaque<std::vector<T>> : public opaque_base<std::vector<T>> {
  public:
    using opaque_base<std::vector<T>>::opaque_base;
 
-   size_t unpack_size() {
-      uint32_t num;
-      varuint32_from_bin(num, this->bin);
+   /** Determine the size of the vector to be unpacked.
+
+    @pre this->empty() should be false.
+   */
+   uint64_t unpack_size() {
+      uint64_t num;
+      varuint64_from_bin(num, this->bin);
       return num;
    }
 


### PR DESCRIPTION
- Modify the deserialization example in the comment, so it shows that we have to check that the opaque is not empty before calling unpack_size().
- Add this precondition to the documentation of the method.
- Increase the type of the return value for unpack_size(), to allow the possibility of large vectors.