### PR TITLE
Some interface improvement

### DIFF
--- a/include/eosio/opaque.hpp
+++ b/include/eosio/opaque.hpp
@@ -8,16 +8,16 @@ namespace eosio {
 
 ///
 /// opaque<T> type provides a type safe alternative to input_stream to declare a field
-/// to be skiped during deserialization of its containing data structure. Afterwards, 
-/// the underlying value can be restored with correct type information. 
+/// to be skiped during deserialization of its containing data structure. Afterwards,
+/// the underlying value can be restored with correct type information.
 ///
-/// The serialization opaque<T> consists of a variable length byte count followed by the 
+/// The serialization opaque<T> consists of a variable length byte count followed by the
 /// serialized bytes for a value of type T. The purpose to serialized as opaque<T> as oppose
 /// to T is to allow the client to delay deserialization until the value is actually needed and
-/// thus saving some CPU cycles or memory requirement. 
+/// thus saving some CPU cycles or memory requirement.
 ///
 /// For example, given a foo_type,
-/// 
+///
 /// <code>
 ///    struct foo_type {
 ///      uint32_t                    field1;
@@ -25,22 +25,22 @@ namespace eosio {
 ///      opaque<std::vector<string>> field3;
 ///    };
 /// </code>
-///   
+///
 /// the deserialization can be implemented as follows:
-/// 
-/// <code>  
+///
+/// <code>
 ///   input_stream serialized_foo_stream(...);
-///   foo_type foo_value; 
+///   foo_type foo_value;
 ///   from_bin(foo_value, serialized_foo_stream);
 ///   if (foo_value.field1 > 1 || foo_value.field2 == "meet_precondition") {
 ///      if(!foo_value.field3.empty()) {
-///         auto sz = foo_value.field3.unpack_size();
-///         for (size_t i = 0; i < sz; ++i) {
-///            if (foo_value.field3.unpack_next() == "value_to_be_searched") {
-///               do_something_when_found();
-///               break;
-///            }
-///         }
+///         loop_until(foo_value.field3, [](const auto& x) {
+///             if (x.size() > 1) {
+///                return true;
+///             }
+///             do_something(x);
+///             return false;
+///         });
 ///      }
 ///   }
 /// </code>
@@ -50,43 +50,50 @@ class opaque_base {
  protected:
    input_stream bin;
 
+   opaque_base(input_stream b) : bin(b) {}
+
  public:
    opaque_base() = default;
    explicit opaque_base(const std::vector<char>& data) : bin(data) {}
 
    /**
-      @pre this->empty() should be false.
-   */
-   void unpack(T& obj) { eosio::from_bin(obj, bin); }
+    * @pre !this->empty()
+    */
+   [[deprecated("Use unpack() free function instead.")]] void unpack(T& obj) { eosio::from_bin(obj, bin); }
 
    /**
-      @pre this->empty() should be false.
-   */
-   T unpack() {
+    *   @pre !this->empty()
+    */
+   [[deprecated("Use unpack() free function instead.")]] T unpack() {
       T obj;
       this->unpack(obj);
       return obj;
    }
 
-   bool empty() const { return !bin.remaining(); }
-   size_t num_bytes() const { return bin.remaining();  }
+   bool   empty() const { return !bin.remaining(); }
+   size_t num_bytes() const { return bin.remaining(); }
 
    template <typename S>
    void from(S& stream) {
       eosio::from_bin(this->bin, stream);
    }
 
-  template <typename S>
-  void to_bin(S& stream) const {
-    eosio::to_bin(this->bin, stream);
-  }
+   template <typename S>
+   void to_bin(S& stream) const {
+      eosio::to_bin(this->bin, stream);
+   }
 
+   input_stream get() const { return bin; }
 };
 
 template <typename T>
 class opaque : public opaque_base<T> {
  public:
    using opaque_base<T>::opaque_base;
+
+   template <typename U, typename = std::enable_if_t<std::is_base_of_v<T, U>>>
+   opaque(opaque<U> other) : opaque_base<T>(other.bin) {}
+
    template <typename U>
    friend opaque<U> as_opaque(input_stream bin);
 };
@@ -97,18 +104,20 @@ class opaque<std::vector<T>> : public opaque_base<std::vector<T>> {
    using opaque_base<std::vector<T>>::opaque_base;
 
    /** Determine the size of the vector to be unpacked.
-
-      @pre this->empty() should be false.
-   */
-   uint64_t unpack_size() {
+    *
+    *   @pre !this->empty()
+    */
+   [[deprecated("Use for_each() or loop_until() free function instead.")]] uint64_t unpack_size() {
       uint64_t num;
       varuint64_from_bin(num, this->bin);
       return num;
    }
 
-   void unpack_next(T& obj) { eosio::from_bin(obj, this->bin); }
+   [[deprecated("Use for_each() or loop_until() free function instead.")]] void unpack_next(T& obj) {
+      eosio::from_bin(obj, this->bin);
+   }
 
-   T unpack_next() {
+   [[deprecated("Use for_each() or loop_until() free function instead.")]] T unpack_next() {
       T obj;
       this->unpack_next(obj);
       return obj;
@@ -138,6 +147,37 @@ opaque<U> as_opaque(input_stream bin) {
    opaque<U> result;
    result.bin = bin;
    return result;
+}
+
+template <typename T, typename U>
+std::enable_if_t<std::is_base_of_v<U, T>, bool> unpack(opaque<T> opq, U& obj) {
+   if (opq.empty())
+      return false;
+   eosio::from_bin(obj, opq.get());
+   return true;
+}
+
+template <typename T, typename Predicate>
+void loop_until(opaque<std::vector<T>> opq, Predicate&& f) {
+   if (opq.empty())
+      return;
+   input_stream bin = opq.get();
+   uint64_t     num;
+   varuint64_from_bin(num, bin);
+   for (uint64_t i = 0; i < num; ++i) {
+      T obj;
+      eosio::from_bin(obj, bin);
+      if (f(std::move(obj)))
+         return;
+   }
+}
+
+template <typename T, typename UnaryFunction>
+void for_each(opaque<std::vector<T>> opq, UnaryFunction&& f) {
+   loop_until(opq, [&f](auto&& x) {
+      f(std::forward<decltype(x)>(x));
+      return false;
+   });
 }
 
 } // namespace eosio

--- a/include/eosio/opaque.hpp
+++ b/include/eosio/opaque.hpp
@@ -53,7 +53,6 @@ class opaque_base {
  public:
    opaque_base() = default;
    explicit opaque_base(const std::vector<char>& data) : bin(data) {}
-   explicit opaque_base(input_stream strm) { eosio::from_bin(bin, strm); }
 
    /**
       @pre this->empty() should be false.
@@ -88,6 +87,8 @@ template <typename T>
 class opaque : public opaque_base<T> {
  public:
    using opaque_base<T>::opaque_base;
+   template <typename U>
+   friend opaque<U> as_opaque(input_stream bin);
 };
 
 template <typename T>
@@ -113,6 +114,8 @@ class opaque<std::vector<T>> : public opaque_base<std::vector<T>> {
       return obj;
    }
 
+   template <typename U>
+   friend opaque<U> as_opaque(input_stream bin);
 };
 
 template <typename T>
@@ -125,9 +128,16 @@ void from_bin(opaque<T>& obj, S& stream) {
    obj.from(stream);
 }
 
-  template <typename T, typename S>
-  void to_bin(const opaque<T>& obj, S& stream) {
-    obj.to_bin(stream);
-  }
+template <typename T, typename S>
+void to_bin(const opaque<T>& obj, S& stream) {
+   obj.to_bin(stream);
+}
+
+template <typename U>
+opaque<U> as_opaque(input_stream bin) {
+   opaque<U> result;
+   result.bin = bin;
+   return result;
+}
 
 } // namespace eosio

--- a/include/eosio/reflection.hpp
+++ b/include/eosio/reflection.hpp
@@ -35,7 +35,7 @@ namespace eosio { namespace reflection {
    eosio_for_each_field((EOSIO_REFLECT_STRIP_BASE##BASE*)nullptr, f);
 
 #define EOSIO_REFLECT_SIGNATURE(STRUCT, ...)                                                                           \
-   [[maybe_unused]] inline const char* get_type_name(STRUCT*) { return #STRUCT; }                                      \
+   [[maybe_unused]] inline constexpr const char* get_type_name(STRUCT*) { return #STRUCT; }                                      \
    template <typename F>                                                                                               \
    constexpr void eosio_for_each_field(STRUCT*, F f)
 

--- a/include/eosio/types.hpp
+++ b/include/eosio/types.hpp
@@ -89,9 +89,15 @@ constexpr auto get_variant_type_name() {
 template <typename... T>
 constexpr auto variant_type_name = get_variant_type_name<T...>();
 
+} // namespace eosio
+
+namespace std {
+// For all the types defined in ship_protocal.hpp, it relies on the argument-dependent name lookup
+// to work; that is, the get_type_name() should be defined in the namespace which is the same namespace of
+// the first argument. For variant, it is defined in the namespace; therefore, we need to define get_type_name()
+// in the std namespace.
 template <typename... T>
 constexpr const char* get_type_name(std::variant<T...>*) {
-   return variant_type_name<T...>.data();
+   return eosio::variant_type_name<T...>.data();
 }
-
-} // namespace eosio
+}

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -40,39 +40,7 @@ template <typename F>
 constexpr void for_each_abi_type(F f) {
     static_assert(sizeof(float) == 4);
     static_assert(sizeof(double) == 8);
-
-    using namespace ::abieos;
-    f((bool*)nullptr);
-    f((int8_t*)nullptr);
-    f((uint8_t*)nullptr);
-    f((int16_t*)nullptr);
-    f((uint16_t*)nullptr);
-    f((int32_t*)nullptr);
-    f((uint32_t*)nullptr);
-    f((int64_t*)nullptr);
-    f((uint64_t*)nullptr);
-    f((int128*)nullptr);
-    f((uint128*)nullptr);
-    f((varuint32*)nullptr);
-    f((varint32*)nullptr);
-    f((float*)nullptr);
-    f((double*)nullptr);
-    f((float128*)nullptr);
-    f((time_point*)nullptr);
-    f((time_point_sec*)nullptr);
-    f((block_timestamp*)nullptr);
-    f((name*)nullptr);
-    f((bytes*)nullptr);
-    f((std::string*)nullptr);
-    f((checksum160*)nullptr);
-    f((checksum256*)nullptr);
-    f((checksum512*)nullptr);
-    f((public_key*)nullptr);
-    f((private_key*)nullptr);
-    f((signature*)nullptr);
-    f((symbol*)nullptr);
-    f((symbol_code*)nullptr);
-    f((asset*)nullptr);
+    std::apply([&f](auto&& ...t) { (f(&t), ...); }, basic_abi_types{});
 }
 
 abi_type* get_type(std::map<std::string, abi_type>& abi_types,


### PR DESCRIPTION
This PR provides two improvement:
   * `opaque<T>` interfaces: based on past experiences; the existing interfaces are still too error-prone to use, such as forgetting check the opaque is empty before calling `unpack()` or trying to call `opaque<std::vector<T>>::unpack()` after `unpack_size()` is called. This PR tries to address those issues by deprecating the existing member function interfaces and providing higher level free function alternatives: `unpack()`, `for_each()` and `loop_unitl()`.
   * `eosio::add_type()`: in the EOS repo, there's a copy of json representation of the ship_protocol which it is used by fill-pg to decode the message. However, the json representation of the  ship_protocol is constantly out of date with the types defined in ship_protocol.hpp. The changes for `eosio::add_type()` are aimed to make it possible to generates the json abi from the types in ship_protocol.hpp. 