### PR TITLE
Huangminghuang/bug fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,21 @@ endif()
 find_package(Threads)
 
 add_library(abieos STATIC src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
-target_include_directories(abieos PUBLIC include external/rapidjson/include)
+target_include_directories(abieos PUBLIC 
+                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include" 
+                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/external/rapidjson/include"
+                          "$<INSTALL_INTERFACE:include>")
 
 if(ABIEOS_NO_INT128)
 target_compile_definitions(abieos PUBLIC ABIEOS_NO_INT128)
 endif()
 
 add_library(abieos_module MODULE src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
-target_include_directories(abieos_module PUBLIC include external/rapidjson/include)
+target_include_directories(abieos_module PUBLIC 
+                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include;" 
+                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/external/rapidjson/include" 
+                          "$<INSTALL_INTERFACE:include>")
+
 target_link_libraries(abieos_module ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(abieos_module PROPERTIES OUTPUT_NAME "abieos")
 
@@ -86,3 +93,24 @@ endif()
 if (NOT ABIEOS_ONLY_LIBRARY)
 add_subdirectory(tools)
 endif()
+
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/eosio DESTINATION include)
+
+install(TARGETS abieos
+  EXPORT abieos
+	INCLUDES DESTINATION include
+	ARCHIVE
+)
+
+install(EXPORT abieos
+  DESTINATION "share/abieos"
+  FILE abieos-targets.cmake
+)
+
+export(TARGETS abieos 
+       FILE ${CMAKE_CURRENT_BINARY_DIR}/share/abieos/abieos-targets.cmake)
+configure_file(abieos-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/share/abieos/abieos-config.cmake COPYONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/abieos/abieos-config.cmake
+        DESTINATION "share/abieos")

--- a/abieos-config.cmake.in
+++ b/abieos-config.cmake.in
@@ -1,0 +1,4 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Boost)
+find_dependency(RapidJSON)
+include ("${CMAKE_CURRENT_LIST_DIR}/abieos-targets.cmake")

--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -279,7 +279,7 @@ extern const abi_serializer* const optional_abi_serializer;
 using basic_abi_types =
       std::tuple<bool, int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t, uint64_t, __int128, unsigned __int128,
                varuint32, varint32, float, double, float128, time_point, time_point_sec, block_timestamp, name,
-               bytes, std::string, checksum160, checksum256, checksum256, public_key, private_key, signature,
+               bytes, std::string, checksum160, checksum256, checksum256, checksum512, public_key, private_key, signature,
                symbol, symbol_code, asset>;
 
 namespace detail {

--- a/include/eosio/opaque.hpp
+++ b/include/eosio/opaque.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "to_bin.hpp"
 #include "from_bin.hpp"
 #include "stream.hpp"
 #include "types.hpp"


### PR DESCRIPTION
This PR:

- fix `checksum512` not included in `basic_abi_types` which breaks unit test,
- add missing include in `opaque.hpp` which prevent it being use for marshalling, 
- add cmake install target