### PR TITLE
Huangminghuang/ship v2

### DIFF
--- a/include/eosio/opaque.hpp
+++ b/include/eosio/opaque.hpp
@@ -153,7 +153,8 @@ template <typename T, typename U>
 std::enable_if_t<std::is_base_of_v<U, T>, bool> unpack(opaque<T> opq, U& obj) {
    if (opq.empty())
       return false;
-   eosio::from_bin(obj, opq.get());
+   input_stream bin = opq.get();
+   eosio::from_bin(obj, bin);
    return true;
 }
 


### PR DESCRIPTION
- fix `opaque::unpack()` where the `eosio::from_bin` requires the lvalue for `bin`,
- add `get_blocks_request_v1` and `get_blocks_result_v2` for ship protocol to request and return block header only
- extract  int_to_decimal() from int_to_json() so that it can be reused by fill-pg