### PR TITLE
fix handling alias type

### DIFF
--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -243,6 +243,14 @@ struct abi_type {
    const struct_* as_struct() const { return std::get_if<struct_>(&_data); }
    const variant* as_variant() const { return std::get_if<variant>(&_data); }
 
+   const abi_serializer* get_serializer() const { 
+      const alias* a = std::get_if<alias>(&_data);
+      if (a) {
+         return a->type->get_serializer();
+      }
+      return ser;
+   }
+
    std::string bin_to_json(
          input_stream& bin, std::function<void()> f = [] {}) const;
    std::vector<char> json_to_bin(

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -68,7 +68,7 @@ abi_type* get_type(std::map<std::string, abi_type>& abi_types,
             auto [iter, success] = abi_types.try_emplace(name, name, abi_type::extension{base}, &abi_serializer_for< ::abieos::pseudo_extension>);
             return &iter->second;
         } else
-           eosio::check(false, eosio::convert_abi_error(abi_error::unknown_type));
+           eosio::check(false, std::string("Unknown type ") + name);
     }
 
     // resolve aliases


### PR DESCRIPTION
Fix accessing `ser` for `abi_type` when it contains an alias. 