### PR TITLE
Remove transaction hook - eosio-2.1.x

### DIFF
--- a/include/eosio/ship_protocol.hpp
+++ b/include/eosio/ship_protocol.hpp
@@ -759,31 +759,7 @@ namespace eosio { namespace ship_protocol {
                  max_linear_memory_init, max_func_local_bytes, max_nested_structures, max_symbol_bytes,
                  max_module_bytes, max_code_bytes, max_pages, max_call_depth)
 
-   struct transaction_hook {
-      uint32_t type;
-      name     contract;
-      name     action;
-   };
-
-   EOSIO_REFLECT(transaction_hook, type, contract, action)
-
-   struct global_property_extension_v0 {
-      uint32_t                      proposed_security_group_block_num = 0;
-      std::vector<name>             proposed_security_group_participants;
-      std::vector<transaction_hook> transaction_hooks;
-   };
-
-   EOSIO_REFLECT(global_property_extension_v0, proposed_security_group_block_num, proposed_security_group_participants, transaction_hooks)
-
-   struct global_property_v2 : global_property_v1 {
-      kv_database_config                         kv_configuration;
-      wasm_config                                wasm_configuration;
-      std::variant<global_property_extension_v0> extension;
-   };
-
-   EOSIO_REFLECT(global_property_v2, base global_property_v1, kv_configuration, wasm_configuration, extension)
-
-   using global_property = std::variant<global_property_v0, global_property_v1, global_property_v2>;
+   using global_property = std::variant<global_property_v0, global_property_v1>;
 
    struct generated_transaction_v0 {
       eosio::name         sender     = {};


### PR DESCRIPTION
Removed global_property_v2, which was not used on 2.1.x branch.