### PR TITLE
to_json() / from_json() to be clearly unable to work with enums

### DIFF
--- a/include/eosio/from_json.hpp
+++ b/include/eosio/from_json.hpp
@@ -649,7 +649,7 @@ void from_json_skip_value(S& stream) {
 /// \output_section Parse JSON (Reflected Objects)
 /// Parse JSON and convert to `obj`. This overload works with
 /// [reflected objects](standardese://reflection/).
-template <typename T, typename S>
+template <typename T, typename S, typename std::enable_if_t<std::is_enum_v<T>, bool> = false>
 void from_json(T& obj, S& stream) {
    from_json_object(stream, [&](std::string_view key) {
       bool found = false;

--- a/include/eosio/from_json.hpp
+++ b/include/eosio/from_json.hpp
@@ -363,10 +363,6 @@ template <typename SrcIt, typename DestIt>
    return true;
 }
 
-/// \exclude
-template <typename T, typename S>
-void from_json(T& result, S& stream);
-
 /// \group from_json_explicit Parse JSON (Explicit Types)
 /// Parse JSON and convert to `result`. These overloads handle specified types.
 template <typename S>
@@ -649,7 +645,7 @@ void from_json_skip_value(S& stream) {
 /// \output_section Parse JSON (Reflected Objects)
 /// Parse JSON and convert to `obj`. This overload works with
 /// [reflected objects](standardese://reflection/).
-template <typename T, typename S, typename std::enable_if_t<std::is_enum_v<T>, bool> = false>
+template <typename T, typename S, typename std::enable_if_t<!std::is_enum_v<T>, bool> = true>
 void from_json(T& obj, S& stream) {
    from_json_object(stream, [&](std::string_view key) {
       bool found = false;

--- a/include/eosio/to_json.hpp
+++ b/include/eosio/to_json.hpp
@@ -254,7 +254,7 @@ void to_json(const std::variant<T...>& obj, S& stream) {
       using value_type = T;
    };
 
-template <typename T, typename S>
+template <typename T, typename S, typename std::enable_if_t<std::is_enum_v<T>, bool> = false>
 void to_json(const T& t, S& stream) {
    bool         first = true;
    stream.write('{');

--- a/include/eosio/to_json.hpp
+++ b/include/eosio/to_json.hpp
@@ -254,7 +254,7 @@ void to_json(const std::variant<T...>& obj, S& stream) {
       using value_type = T;
    };
 
-template <typename T, typename S, typename std::enable_if_t<std::is_enum_v<T>, bool> = false>
+template <typename T, typename S, typename std::enable_if_t<!std::is_enum_v<T>, bool> = true>
 void to_json(const T& t, S& stream) {
    bool         first = true;
    stream.write('{');


### PR DESCRIPTION
made `to_json()` / `from_json()` be clearly unable to work with enums. Without this change they were still not able to work with enums but the compilation error was different.

I'll be adding our own versions of these functions in Bullish code base with the enum support.