### PR TITLE
Support cross compiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_CXX_EXTENSIONS ON)
 
 option(ABIEOS_NO_INT128 "disable use of __int128" OFF)
 option(ABIEOS_ONLY_LIBRARY "define and build the ABIEOS library" OFF)
-option(BUILD_SHARED_LIBS "build ABIEOS share library" ON)
+option(ABIEOS_BUILD_SHARED_LIB "build ABIEOS share library" ON)
 
 if(NOT DEFINED SKIP_SUBMODULE_CHECK)
   execute_process(COMMAND git submodule status --recursive
@@ -46,7 +46,7 @@ if(ABIEOS_NO_INT128)
 target_compile_definitions(abieos PUBLIC ABIEOS_NO_INT128)
 endif()
 
-if (BUILD_SHARED_LIBS)
+if (ABIEOS_BUILD_SHARED_LIB)
   add_library(abieos_module MODULE src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
   target_include_directories(abieos_module PUBLIC 
                             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include;" 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_CXX_EXTENSIONS ON)
 
 option(ABIEOS_NO_INT128 "disable use of __int128" OFF)
 option(ABIEOS_ONLY_LIBRARY "define and build the ABIEOS library" OFF)
+option(BUILD_SHARED_LIBS "build ABIEOS share library" ON)
 
 if(NOT DEFINED SKIP_SUBMODULE_CHECK)
   execute_process(COMMAND git submodule status --recursive
@@ -45,26 +46,43 @@ if(ABIEOS_NO_INT128)
 target_compile_definitions(abieos PUBLIC ABIEOS_NO_INT128)
 endif()
 
-add_library(abieos_module MODULE src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
-target_include_directories(abieos_module PUBLIC 
-                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include;" 
-                          "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/external/rapidjson/include" 
-                          "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+if (BUILD_SHARED_LIBS)
+  add_library(abieos_module MODULE src/abieos.cpp src/abi.cpp src/crypto.cpp include/eosio/fpconv.c)
+  target_include_directories(abieos_module PUBLIC 
+                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/include;" 
+                            "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/external/rapidjson/include" 
+                            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
-target_link_libraries(abieos_module ${CMAKE_THREAD_LIBS_INIT})
-set_target_properties(abieos_module PROPERTIES OUTPUT_NAME "abieos")
+  target_link_libraries(abieos_module ${CMAKE_THREAD_LIBS_INIT})
+  set_target_properties(abieos_module PROPERTIES OUTPUT_NAME "abieos")
+endif()
 
-add_executable(ship_abi_gen src/ship_abi_gen.cpp)
-target_link_libraries(ship_abi_gen abieos ${CMAKE_THREAD_LIBS_INIT})
-add_custom_command(OUTPUT ship_abi.json 
-                   COMMAND ship_abi_gen > ship_abi.json 
-                   DEPENDS ship_abi_gen)
+if (NOT CMAKE_CROSSCOMPILING)
+  add_executable(ship_abi_gen src/ship_abi_gen.cpp)
+  target_link_libraries(ship_abi_gen abieos ${CMAKE_THREAD_LIBS_INIT})
+  add_custom_command(OUTPUT ship_abi.json 
+                    COMMAND ship_abi_gen > ship_abi.json 
+                    DEPENDS ship_abi_gen)
+
+  add_custom_target(ship_abi_json
+    DEPENDS ship_abi.json 
+  )
+
+else()
+  include(ExternalProject)
+  externalproject_add(ship_abi_json
+                    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+                    CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}" "-DCMAKE_BUILD_TYPE=Release"
+                    BUILD_COMMAND ${CMAKE_COMMAND} --build . --target install.ship_abi_json
+                    BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/ship_abi.json
+                    INSTALL_COMMAND "")
+endif()
 
 add_custom_command(OUTPUT ship_abi.cpp
   COMMAND ${CMAKE_COMMAND} -E echo "namespace eosio { namespace ship_protocol { extern const char* const ship_abi = R\"(" > ship_abi.cpp
   COMMAND ${CMAKE_COMMAND} -E cat  ${CMAKE_CURRENT_BINARY_DIR}/ship_abi.json >> ship_abi.cpp
   COMMAND ${CMAKE_COMMAND} -E echo ")\"; }}" >> ship_abi.cpp
-  DEPENDS ship_abi.json 
+  DEPENDS ship_abi_json 
   VERBATIM
 )
 
@@ -131,3 +149,7 @@ configure_file(abieos-config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/share/abieos/a
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/abieos/abieos-config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/ship_abi.json 
         DESTINATION "share/abieos")
+
+add_custom_target(install.ship_abi_json
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/ship_abi.json ${CMAKE_INSTALL_PREFIX}
+        DEPENDS ship_abi.json)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,9 @@ else()
 endif()
 
 add_custom_command(OUTPUT ship_abi.cpp
-  COMMAND ${CMAKE_COMMAND} -E echo "namespace eosio { namespace ship_protocol { extern const char* const ship_abi = R\"(" > ship_abi.cpp
-  COMMAND ${CMAKE_COMMAND} -E cat  ${CMAKE_CURRENT_BINARY_DIR}/ship_abi.json >> ship_abi.cpp
-  COMMAND ${CMAKE_COMMAND} -E echo ")\"; }}" >> ship_abi.cpp
+  COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/gen_ship_abi_cpp.cmake 
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ship_abi_json 
-  VERBATIM
 )
 
 add_library(ship_abi ${CMAKE_CURRENT_BINARY_DIR}/ship_abi.cpp)

--- a/gen_ship_abi_cpp.cmake
+++ b/gen_ship_abi_cpp.cmake
@@ -1,0 +1,4 @@
+file(READ "ship_abi.json" SHIP_ABI_JSON)
+file(WRITE "ship_abi.cpp"  "namespace eosio { namespace ship_protocol { extern const char* const ship_abi = R\"(")
+file(APPEND "ship_abi.cpp" "${SHIP_ABI_JSON}")
+file(APPEND "ship_abi.cpp"  ")\"; }}")


### PR DESCRIPTION
This PR 
  - add new option `BUILD_SHARED_LIBS` to control whether to build the shared abieos library
  - add cross-compilation support cross-compilation for make and ninja generators due to the changes from PR #123.
  - fix problem with cmake 3.17 and below