### PR TITLE
To support std::array (currently part support, some functions are emp…

### DIFF
--- a/include/eosio/abi.hpp
+++ b/include/eosio/abi.hpp
@@ -205,12 +205,15 @@ struct abi_type {
    struct array {
       abi_type* type;
    };
+   struct szarray {
+      abi_type* type;
+   };
    struct struct_ {
       abi_type*              base = nullptr;
       std::vector<abi_field> fields;
    };
    using variant = std::vector<abi_field>;
-   std::variant<builtin, const alias_def*, const struct_def*, const variant_def*, alias, optional, extension, array,
+   std::variant<builtin, const alias_def*, const struct_def*, const variant_def*, alias, optional, extension, array, szarray,
                 struct_, variant>
                          _data;
    const abi_serializer* ser = nullptr;
@@ -240,6 +243,13 @@ struct abi_type {
       else
          return nullptr;
    }
+   const abi_type* szarray_of() const {
+      if (auto* t = std::get_if<szarray>(&_data))
+         return t->type;
+      else
+         return nullptr;
+   }
+
    const struct_* as_struct() const { return std::get_if<struct_>(&_data); }
    const variant* as_variant() const { return std::get_if<variant>(&_data); }
 
@@ -281,6 +291,7 @@ void convert(const abi& def, abi_def&);
 extern const abi_serializer* const object_abi_serializer;
 extern const abi_serializer* const variant_abi_serializer;
 extern const abi_serializer* const array_abi_serializer;
+extern const abi_serializer* const szarray_abi_serializer;
 extern const abi_serializer* const extension_abi_serializer;
 extern const abi_serializer* const optional_abi_serializer;
 

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -10,6 +10,17 @@ bool ends_with(const std::string& s, const char (&suffix)[i]) {
     return s.size() >= i - 1 && !strcmp(s.c_str() + s.size() - (i - 1), suffix);
 }
 
+bool is_szarray(const std::string& s){
+   int n = s.size();
+   if(n < 3) return false;
+   if(s[n-1] != ']') return false;
+   int i = n -2;
+   if(!(s[i] >= '0' && s[i] <= '9')) return false;
+   while(i >=0 &&  s[i] >= '0' && s[i] <= '9' ) --i;
+   if(i < 0  || s[i] != '[' ) return false;
+   return true;
+}
+
 template <typename T>
 struct abi_serializer_impl : abi_serializer {
     void json_to_bin(::abieos::jvalue_to_bin_state& state, bool allow_extensions, const abi_type* type,
@@ -51,15 +62,22 @@ abi_type* get_type(std::map<std::string, abi_type>& abi_types,
     if (it == abi_types.end()) {
         if (ends_with(name, "?")) {
             auto base = get_type(abi_types, name.substr(0, name.size() - 1), depth + 1);
-            eosio::check(!holds_any_alternative<abi_type::optional, abi_type::array, abi_type::extension>(base->_data),
+            eosio::check(!holds_any_alternative<abi_type::optional, abi_type::array, abi_type::szarray, abi_type::extension>(base->_data),
                   eosio::convert_abi_error(abi_error::invalid_nesting));
             auto [iter, success] = abi_types.try_emplace(name, name, abi_type::optional{base}, &abi_serializer_for< ::abieos::pseudo_optional>);
             return &iter->second;
         } else if (ends_with(name, "[]")) {
             auto element = get_type(abi_types, name.substr(0, name.size() - 2), depth + 1);
-            eosio::check(!holds_any_alternative<abi_type::optional, abi_type::array, abi_type::extension>(element->_data),
+            eosio::check(!holds_any_alternative<abi_type::optional, abi_type::array, abi_type::szarray, abi_type::extension>(element->_data),
                   eosio::convert_abi_error(abi_error::invalid_nesting));
             auto [iter, success] = abi_types.try_emplace(name, name, abi_type::array{element}, &abi_serializer_for< ::abieos::pseudo_array>);
+            return &iter->second;
+         } else if(is_szarray(name) ){
+            int pos = name.find_last_of('[');
+            auto element = get_type(abi_types, name.substr(0, pos), depth + 1);
+            eosio::check(!holds_any_alternative< abi_type::szarray, abi_type::extension>(element->_data),
+                  eosio::convert_abi_error(abi_error::invalid_nesting));
+            auto [iter, success] = abi_types.try_emplace(name, name, abi_type::szarray{element}, &abi_serializer_for< ::abieos::pseudo_szarray>);
             return &iter->second;
         } else if (ends_with(name, "$")) {
             auto base = get_type(abi_types, name.substr(0, name.size() - 1), depth + 1);
@@ -205,6 +223,7 @@ void eosio::convert(const abi_def& abi, eosio::abi& c) {
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::builtin&) {}
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::optional&) {}
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::array&) {}
+void to_abi_def(abi_def& def, const std::string& name, const abi_type::szarray&) {}
 void to_abi_def(abi_def& def, const std::string& name, const abi_type::extension&) {}
 
 template<typename T>
@@ -250,6 +269,7 @@ void eosio::convert(const eosio::abi& abi, eosio::abi_def& def) {
 const abi_serializer* const eosio::object_abi_serializer = &abi_serializer_for< ::abieos::pseudo_object>;
 const abi_serializer* const eosio::variant_abi_serializer = &abi_serializer_for< ::abieos::pseudo_variant>;
 const abi_serializer* const eosio::array_abi_serializer = &abi_serializer_for< ::abieos::pseudo_array>;
+const abi_serializer* const eosio::szarray_abi_serializer = &abi_serializer_for< ::abieos::pseudo_szarray>;
 const abi_serializer* const eosio::extension_abi_serializer = &abi_serializer_for< ::abieos::pseudo_extension>;
 const abi_serializer* const eosio::optional_abi_serializer = &abi_serializer_for< ::abieos::pseudo_optional>;
 

--- a/src/abi.cpp
+++ b/src/abi.cpp
@@ -75,7 +75,7 @@ abi_type* get_type(std::map<std::string, abi_type>& abi_types,
          } else if(is_szarray(name) ){
             int pos = name.find_last_of('[');
             auto element = get_type(abi_types, name.substr(0, pos), depth + 1);
-            eosio::check(!holds_any_alternative< abi_type::szarray, abi_type::extension>(element->_data),
+            eosio::check(!holds_any_alternative<abi_type::optional, abi_type::array, abi_type::szarray, abi_type::extension>(element->_data),
                   eosio::convert_abi_error(abi_error::invalid_nesting));
             auto [iter, success] = abi_types.try_emplace(name, name, abi_type::szarray{element}, &abi_serializer_for< ::abieos::pseudo_szarray>);
             return &iter->second;

--- a/src/abieos.hpp
+++ b/src/abieos.hpp
@@ -61,6 +61,7 @@ struct pseudo_optional;
 struct pseudo_extension;
 struct pseudo_object;
 struct pseudo_array;
+struct pseudo_szarray;
 struct pseudo_variant;
 
 // !!!
@@ -321,6 +322,8 @@ void json_to_bin(pseudo_object*, jvalue_to_bin_state& state, bool allow_extensio
                                 const abi_type* type, bool start);
 void json_to_bin(pseudo_array*, jvalue_to_bin_state& state, bool allow_extensions,
                                 const abi_type* type, bool start);
+void json_to_bin(pseudo_szarray*, jvalue_to_bin_state& state, bool allow_extensions,
+                                const abi_type* type, bool start);
 void json_to_bin(pseudo_variant*, jvalue_to_bin_state& state, bool allow_extensions,
                                 const abi_type* type, bool start);
 
@@ -328,6 +331,8 @@ void json_to_bin(pseudo_object*, json_to_bin_state& state, bool allow_extensions
                                 bool start);
 void json_to_bin(pseudo_array*, json_to_bin_state& state, bool allow_extensions, const abi_type* type,
                                 bool start);
+void json_to_bin(pseudo_szarray*, json_to_bin_state& state, bool allow_extensions, const abi_type* type,
+                                 bool start);
 void json_to_bin(pseudo_variant*, json_to_bin_state& state, bool allow_extensions,
                                 const abi_type* type, bool start);
 
@@ -338,6 +343,8 @@ void bin_to_json(pseudo_extension*, bin_to_json_state& state, bool allow_extensi
 void bin_to_json(pseudo_object*, bin_to_json_state& state, bool allow_extensions, const abi_type* type,
                                 bool start);
 void bin_to_json(pseudo_array*, bin_to_json_state& state, bool allow_extensions, const abi_type* type,
+                                bool start);
+void bin_to_json(pseudo_szarray*, bin_to_json_state& state, bool allow_extensions, const abi_type* type,
                                 bool start);
 void bin_to_json(pseudo_variant*, bin_to_json_state& state, bool allow_extensions,
                                 const abi_type* type, bool start);
@@ -654,6 +661,8 @@ inline void json_to_bin(pseudo_object*, jvalue_to_bin_state& state, bool allow_e
                                         field.type, true);
 }
 
+inline void json_to_bin(pseudo_szarray*, jvalue_to_bin_state& state, bool, const abi_type* type, bool start) {}
+
 inline void json_to_bin(pseudo_array*, jvalue_to_bin_state& state, bool, const abi_type* type,
                                        bool start) {
     if (start) {
@@ -813,6 +822,8 @@ inline void json_to_bin(pseudo_object*, json_to_bin_state& state, bool allow_ext
     }
 }
 
+inline void json_to_bin(pseudo_szarray*, json_to_bin_state& state, bool, const abi_type* type, bool start) {}
+
 inline void json_to_bin(pseudo_array*, json_to_bin_state& state, bool, const abi_type* type,
                                        bool start) {
     if (start) {
@@ -948,6 +959,8 @@ inline void bin_to_json(pseudo_object*, bin_to_json_state& state, bool allow_ext
         state.writer.write('}');
     }
 }
+
+inline void bin_to_json(pseudo_szarray*, bin_to_json_state& state, bool, const abi_type* type, bool start) {}
 
 inline void bin_to_json(pseudo_array*, bin_to_json_state& state, bool, const abi_type* type,
                                          bool start) {


### PR DESCRIPTION
To support std::array (currently part support, some functions are empty but required for compile) , add new type szarray, it means sized array, the type array stand for std::vector.

the function bin_to_json and json_to_bin are empty, it will not really be call if don't pass std::array as a parameter to a action.