### PR TITLE
Huangminghuang/fix-check-no-return

### DIFF
--- a/include/eosio/check.hpp
+++ b/include/eosio/check.hpp
@@ -39,28 +39,28 @@ struct eosio_error : std::exception {
 };
 
 namespace detail {
-   [[noreturn]] inline void assert_or_throw(std::string_view msg) {
+   inline void assert_or_throw(std::string_view msg) {
 #ifdef __eosio_cdt__
          internal_use_do_not_use::eosio_assert_message(false, msg.data(), msg.size());
 #else
          throw std::runtime_error(std::string(msg));
 #endif
    }
-   [[noreturn]] inline void assert_or_throw(const char* msg) {
+   inline void assert_or_throw(const char* msg) {
 #ifdef __eosio_cdt__
          internal_use_do_not_use::eosio_assert(false, msg);
 #else
          throw std::runtime_error(msg);
 #endif
    }
-   [[noreturn]] inline void assert_or_throw(std::string&& msg) {
+   inline void assert_or_throw(std::string&& msg) {
 #ifdef __eosio_cdt__
          internal_use_do_not_use::eosio_assert_message(false, msg.c_str(), msg.size());
 #else
          throw std::runtime_error(std::move(msg));
 #endif
    }
-   [[noreturn]] inline void assert_or_throw(uint64_t code) {
+   inline void assert_or_throw(uint64_t code) {
 #ifdef __eosio_cdt__
          internal_use_do_not_use::eosio_assert_code(false, code);
 #else

--- a/include/eosio/check.hpp
+++ b/include/eosio/check.hpp
@@ -9,11 +9,11 @@
 namespace eosio {
 namespace internal_use_do_not_use {
 extern "C" {
-__attribute__((eosio_wasm_import, noreturn))
+__attribute__((eosio_wasm_import))
 void eosio_assert_message(uint32_t, const char*, uint32_t);
-__attribute__((eosio_wasm_import, noreturn))
+__attribute__((eosio_wasm_import))
 void eosio_assert(uint32_t, const char*);
-__attribute__((eosio_wasm_import, noreturn))
+__attribute__((eosio_wasm_import))
 void eosio_assert_code(uint32_t, uint64_t);
 }
 }


### PR DESCRIPTION
The PR removes the `no_return` attribute for the imported assert functions from CDT. These functions will always return when the first parameter is non-zero. Adding the `no_return` attribute would generate incorrect wasm code. 