### PR TITLE
Avoid compile warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 
+if (POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 option(ABIEOS_NO_INT128 "disable use of __int128" OFF)
 option(ABIEOS_ONLY_LIBRARY "define and build the ABIEOS library" OFF)
 option(ABIEOS_BUILD_SHARED_LIB "build ABIEOS share library" ON)

--- a/src/abieos.cpp
+++ b/src/abieos.cpp
@@ -5,8 +5,6 @@
 
 #include <memory>
 
-inline const bool catch_all = true;
-
 using namespace abieos;
 
 struct abieos_context_s {
@@ -36,13 +34,9 @@ auto handle_exceptions(abieos_context* context, T errval, F f) noexcept -> declt
     try {
         return f();
     } catch (std::exception& e) {
-        if (!catch_all)
-            throw;
         set_error(context, e.what());
         return errval;
     } catch (...) {
-        if (!catch_all)
-            throw;
         set_error(context, "unknown exception");
         return errval;
     }
@@ -52,8 +46,6 @@ extern "C" abieos_context* abieos_create() {
     try {
         return new abieos_context{};
     } catch (...) {
-        if (!catch_all)
-            throw;
         return nullptr;
     }
 }


### PR DESCRIPTION
The PR 
- removes unreachable code which can cause compiler warning in debug mode,
- fix cmake warning when embeded as a subproject.