### PR TITLE
Fix multicharacter literal warnings in gcc

### DIFF
--- a/src/template_test.cpp
+++ b/src/template_test.cpp
@@ -227,9 +227,9 @@ int main() {
    test(private_key{std::in_place_index<1>}, abi, new_abi);
    test(signature{std::in_place_index<0>}, abi, new_abi);
    test(signature{std::in_place_index<1>}, abi, new_abi);
-   test(symbol{unsigned('ZYX\x08')}, abi, new_abi);
-   test(symbol_code{unsigned('ZYXW')}, abi, new_abi);
-   test(asset{5, symbol{'ZYX\x08'}}, abi, new_abi);
+   test(symbol{unsigned(0x5a595808)}, abi, new_abi);
+   test(symbol_code{unsigned(0x5a595857)}, abi, new_abi);
+   test(asset{5, symbol{0x5a595808}}, abi, new_abi);
    test(struct_type{}, abi, new_abi);
    test(struct_type{{1},2,3}, abi, new_abi);
    test(struct_type{{1,2},3,4.0}, abi, new_abi);

--- a/src/template_test.cpp
+++ b/src/template_test.cpp
@@ -227,9 +227,9 @@ int main() {
    test(private_key{std::in_place_index<1>}, abi, new_abi);
    test(signature{std::in_place_index<0>}, abi, new_abi);
    test(signature{std::in_place_index<1>}, abi, new_abi);
-   test(symbol{unsigned(0x5a595808)}, abi, new_abi);
-   test(symbol_code{unsigned(0x5a595857)}, abi, new_abi);
-   test(asset{5, symbol{0x5a595808}}, abi, new_abi);
+   test(symbol{unsigned(0x5a595808)}, abi, new_abi); // 'ZYX\x08'
+   test(symbol_code{unsigned(0x5a595857)}, abi, new_abi); // 'ZYXW'
+   test(asset{5, symbol{0x5a595808}}, abi, new_abi); // 'ZYX\x08'
    test(struct_type{}, abi, new_abi);
    test(struct_type{{1},2,3}, abi, new_abi);
    test(struct_type{{1,2},3,4.0}, abi, new_abi);


### PR DESCRIPTION
Fix multicharacter literal warnings in gcc